### PR TITLE
feat: add sidebar navigation with icons

### DIFF
--- a/frontend/src/components/AppLayout.js
+++ b/frontend/src/components/AppLayout.js
@@ -1,8 +1,19 @@
 // frontend/src/components/AppLayout.js
 
 import React from 'react';
-import { Navbar, Nav, Container, Button } from 'react-bootstrap';
+import { Nav, Button } from 'react-bootstrap';
 import { NavLink, useNavigate } from 'react-router-dom';
+import {
+    Speedometer2,
+    People,
+    Truck,
+    Receipt,
+    Cart,
+    CreditCard,
+    BoxSeam,
+    BarChart,
+    Bank
+} from 'react-bootstrap-icons';
 
 function AppLayout({ children }) {
     const navigate = useNavigate();
@@ -14,31 +25,44 @@ function AppLayout({ children }) {
     };
 
     return (
-        <>
-            <Navbar bg="dark" variant="dark" expand="lg" className="mb-4">
-                <Container>
-                    <Navbar.Brand as={NavLink} to="/dashboard">MyAccountingApp</Navbar.Brand>
-                    <Navbar.Toggle aria-controls="basic-navbar-nav" />
-                    <Navbar.Collapse id="basic-navbar-nav">
-                        <Nav className="me-auto">
-                            <Nav.Link as={NavLink} to="/dashboard">Dashboard</Nav.Link>
-                            <Nav.Link as={NavLink} to="/customers">Customers</Nav.Link>
-                            <Nav.Link as={NavLink} to="/suppliers">Suppliers</Nav.Link>
-                            <Nav.Link as={NavLink} to="/sales">Sales</Nav.Link>
-                            <Nav.Link as={NavLink} to="/purchases">Purchases</Nav.Link>
-                            <Nav.Link as={NavLink} to="/expenses">Expenses</Nav.Link>
-                            <Nav.Link as={NavLink} to="/inventory">Inventory</Nav.Link>
-                            <Nav.Link as={NavLink} to="/reports/profit-loss">Profit & Loss</Nav.Link>
-                            <Nav.Link as={NavLink} to="/accounts">Bank Accounts</Nav.Link>
-                        </Nav>
-                        <Button variant="outline-light" onClick={handleLogout}>Logout</Button>
-                    </Navbar.Collapse>
-                </Container>
-            </Navbar>
-            <Container>
+        <div className="d-flex">
+            <div className="bg-dark text-white d-flex flex-column p-3" style={{ minWidth: '250px', minHeight: '100vh' }}>
+                <h4 className="mb-4">MyAccountingApp</h4>
+                <Nav className="flex-column mb-auto">
+                    <Nav.Link as={NavLink} to="/dashboard" className="text-white d-flex align-items-center mb-2">
+                        <Speedometer2 className="me-2" /> Dashboard
+                    </Nav.Link>
+                    <Nav.Link as={NavLink} to="/customers" className="text-white d-flex align-items-center mb-2">
+                        <People className="me-2" /> Customers
+                    </Nav.Link>
+                    <Nav.Link as={NavLink} to="/suppliers" className="text-white d-flex align-items-center mb-2">
+                        <Truck className="me-2" /> Suppliers
+                    </Nav.Link>
+                    <Nav.Link as={NavLink} to="/sales" className="text-white d-flex align-items-center mb-2">
+                        <Receipt className="me-2" /> Sales
+                    </Nav.Link>
+                    <Nav.Link as={NavLink} to="/purchases" className="text-white d-flex align-items-center mb-2">
+                        <Cart className="me-2" /> Purchases
+                    </Nav.Link>
+                    <Nav.Link as={NavLink} to="/expenses" className="text-white d-flex align-items-center mb-2">
+                        <CreditCard className="me-2" /> Expenses
+                    </Nav.Link>
+                    <Nav.Link as={NavLink} to="/inventory" className="text-white d-flex align-items-center mb-2">
+                        <BoxSeam className="me-2" /> Inventory
+                    </Nav.Link>
+                    <Nav.Link as={NavLink} to="/reports/profit-loss" className="text-white d-flex align-items-center mb-2">
+                        <BarChart className="me-2" /> Profit &amp; Loss
+                    </Nav.Link>
+                    <Nav.Link as={NavLink} to="/accounts" className="text-white d-flex align-items-center mb-2">
+                        <Bank className="me-2" /> Bank Accounts
+                    </Nav.Link>
+                </Nav>
+                <Button variant="outline-light" onClick={handleLogout} className="mt-auto">Logout</Button>
+            </div>
+            <div className="flex-grow-1 p-4">
                 {children}
-            </Container>
-        </>
+            </div>
+        </div>
     );
 }
 

--- a/frontend/src/pages/DashboardPage.js
+++ b/frontend/src/pages/DashboardPage.js
@@ -10,17 +10,15 @@ import { FaUsers, FaDollarSign, FaBoxOpen, FaCreditCard } from 'react-icons/fa';
 
 // A reusable component for our summary cards
 const SummaryCard = ({ title, value, icon, color }) => (
-    <Card className={`mb-4 shadow-sm bg-${color} text-white`}>
-        <Card.Body>
-            <Row>
-                <Col xs={3} className="d-flex align-items-center justify-content-center">
-                    {icon}
-                </Col>
-                <Col xs={9}>
-                    <h5 className="card-title">{title}</h5>
-                    <h3 className="card-text">{value}</h3>
-                </Col>
-            </Row>
+    <Card className={`shadow-sm bg-${color} text-white`}>
+        <Card.Body className="d-flex align-items-center">
+            <div className="me-3">
+                {icon}
+            </div>
+            <div>
+                <h5 className="mb-1">{title}</h5>
+                <h3 className="mb-0">{value}</h3>
+            </div>
         </Card.Body>
     </Card>
 );
@@ -59,7 +57,7 @@ function DashboardPage() {
         <div>
             <h2 className="mb-4">Dashboard</h2>
             {summary && (
-                <Row>
+                <Row className="g-4">
                     <Col md={6} lg={4}>
                         <SummaryCard
                             title="Total Receivables"


### PR DESCRIPTION
## Summary
- move navigation into a persistent left sidebar with icons for key sections
- polish dashboard summary cards with flex layout and consistent spacing

## Testing
- `node node_modules/react-scripts/bin/react-scripts.js test --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a33a9330e0832395f8e0935e37cfa6