### PR TITLE
feat: Add sales report feature

### DIFF
--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -1,7 +1,7 @@
 # backend/api/urls.py
 
 from django.urls import path, include
-from .views import CreateUserView, ExpenseCategoryViewSet, ExpenseViewSet, profit_and_loss_report
+from .views import CreateUserView, ExpenseCategoryViewSet, ExpenseViewSet, profit_and_loss_report, sales_report
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 # --- Import the router and the viewset ---
 from rest_framework.routers import DefaultRouter
@@ -31,6 +31,7 @@ urlpatterns = [
     path('dashboard-summary/', dashboard_summary, name='dashboard-summary'),
     path('auth/register/', CreateUserView.as_view(), name='register'),
     path('reports/profit-loss/', profit_and_loss_report, name='profit-loss-report'),
+    path('reports/sales/', sales_report, name='sales-report'),
 
 
     # --- Add the router's URLs ---

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -257,6 +257,27 @@ def profit_and_loss_report(request):
     return Response(report_data)
 
 
+@api_view(['GET'])
+@permission_classes([IsAuthenticated])
+def sales_report(request):
+    """
+    Provides a sales report for a given date range.
+    """
+    user = request.user
+
+    start_date_str = request.query_params.get('start_date', '2000-01-01')
+    end_date_str = request.query_params.get('end_date', date.today().strftime('%Y-%m-%d'))
+
+    sales_in_range = Sale.objects.filter(
+        created_by=user,
+        sale_date__range=[start_date_str, end_date_str]
+    ).order_by('-sale_date')
+
+    serializer = SaleReadSerializer(sales_in_range, many=True)
+
+    return Response(serializer.data)
+
+
 class PurchaseViewSet(viewsets.ModelViewSet):
     permission_classes = [IsAuthenticated]
 

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -19,6 +19,7 @@ import NewSalePage from './pages/NewSalePage';   // <-- Import
 import SaleDetailPage from './pages/SaleDetailPage';
 import ExpenseListPage from './pages/ExpenseListPage';
 import ProfitLossPage from './pages/ProfitLossPage';
+import SalesReportPage from './pages/SalesReportPage';
 import EditSalePage from './pages/EditSalePage';
 import PurchaseListPage from './pages/PurchaseListPage';
 import PurchaseDetailPage from './pages/PurchaseDetailPage';
@@ -55,7 +56,8 @@ function App() {
                   <Route path="sales/new" element={<NewSalePage />} />
                   <Route path="sales/:id" element={<SaleDetailPage />} />
                   <Route path="expenses" element={<ExpenseListPage />} /> {/* <-- Add Route */}
-                  <Route path="reports/profit-loss" element={<ProfitLossPage />} /> {/* <-- Add Route */}
+                  <Route path="reports/profit-loss" element={<ProfitLossPage />} />
+                  <Route path="reports/sales" element={<SalesReportPage />} />
                   <Route path="sales/:id/edit" element={<EditSalePage />} /> {/* <-- Add Route */}
                   <Route path="purchases" element={<PurchaseListPage />} /> {/* <-- Add Route */}
                   <Route path="purchases/:id" element={<PurchaseDetailPage />} /> {/* <-- Add Route */}

--- a/frontend/src/components/AppLayout.js
+++ b/frontend/src/components/AppLayout.js
@@ -65,6 +65,9 @@ function AppLayout({ children }) {
                     <Nav.Link as={NavLink} to="/reports/profit-loss" className={linkClass}>
                         <BarChart className={iconClass} /> {!collapsed && 'Profit & Loss'}
                     </Nav.Link>
+                    <Nav.Link as={NavLink} to="/reports/sales" className={linkClass}>
+                        <BarChart className={iconClass} /> {!collapsed && 'Sales Report'}
+                    </Nav.Link>
                     <Nav.Link as={NavLink} to="/accounts" className={linkClass}>
                         <Bank className={iconClass} /> {!collapsed && 'Bank Accounts'}
                     </Nav.Link>

--- a/frontend/src/pages/SalesReportPage.js
+++ b/frontend/src/pages/SalesReportPage.js
@@ -1,0 +1,159 @@
+import React, { useState } from 'react';
+import axiosInstance from '../utils/axiosInstance';
+import { Card, Button, Form, Row, Col, Spinner, Alert, Table, Collapse } from 'react-bootstrap';
+
+// Helper to get the first day of the current month
+const getFirstDayOfMonth = () => {
+    const today = new Date();
+    const yyyy = today.getFullYear();
+    const mm = String(today.getMonth() + 1).padStart(2, '0');
+    return `${yyyy}-${mm}-01`;
+};
+
+// Helper to get today's date
+const getTodayDate = () => {
+    const today = new Date();
+    const yyyy = today.getFullYear();
+    const mm = String(today.getMonth() + 1).padStart(2, '0');
+    const dd = String(today.getDate()).padStart(2, '0');
+    return `${yyyy}-${mm}-${dd}`;
+};
+
+function SalesReportPage() {
+    const [reportData, setReportData] = useState([]);
+    const [startDate, setStartDate] = useState(getFirstDayOfMonth());
+    const [endDate, setEndDate] = useState(getTodayDate());
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState('');
+    const [openRows, setOpenRows] = useState({});
+
+    const generateReport = async () => {
+        setLoading(true);
+        setError('');
+        setReportData([]);
+        try {
+            const params = {
+                start_date: startDate,
+                end_date: endDate,
+            };
+            const response = await axiosInstance.get('/reports/sales/', { params });
+            setReportData(response.data);
+        } catch (err) {
+            console.error("Failed to generate report:", err);
+            setError('Could not generate the report. Please try again.');
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const formatCurrency = (amount) => {
+        return `$${parseFloat(amount).toFixed(2)}`;
+    };
+
+    const toggleRow = (id) => {
+        setOpenRows(prev => ({ ...prev, [id]: !prev[id] }));
+    };
+
+    return (
+        <Card>
+            <Card.Header>
+                <h4>Sales Report</h4>
+            </Card.Header>
+            <Card.Body>
+                <Form>
+                    <Row className="align-items-end">
+                        <Col md={4}>
+                            <Form.Group>
+                                <Form.Label>Start Date</Form.Label>
+                                <Form.Control
+                                    type="date"
+                                    value={startDate}
+                                    onChange={(e) => setStartDate(e.target.value)}
+                                />
+                            </Form.Group>
+                        </Col>
+                        <Col md={4}>
+                            <Form.Group>
+                                <Form.Label>End Date</Form.Label>
+                                <Form.Control
+                                    type="date"
+                                    value={endDate}
+                                    onChange={(e) => setEndDate(e.target.value)}
+                                />
+                            </Form.Group>
+                        </Col>
+                        <Col md={4}>
+                            <Button onClick={generateReport} disabled={loading} className="w-100">
+                                {loading ? <Spinner as="span" animation="border" size="sm" /> : 'Generate Report'}
+                            </Button>
+                        </Col>
+                    </Row>
+                </Form>
+
+                {error && <Alert variant="danger" className="mt-4">{error}</Alert>}
+
+                {reportData.length > 0 && (
+                    <div className="mt-4">
+                        <Table striped bordered hover responsive>
+                            <thead>
+                                <tr>
+                                    <th>#</th>
+                                    <th>Date</th>
+                                    <th>Invoice #</th>
+                                    <th>Customer</th>
+                                    <th className="text-end">Total</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {reportData.map((sale) => (
+                                    <React.Fragment key={sale.id}>
+                                        <tr onClick={() => toggleRow(sale.id)} style={{ cursor: 'pointer' }}>
+                                            <td><Button variant="link" size="sm">{openRows[sale.id] ? '-' : '+'}</Button></td>
+                                            <td>{sale.sale_date}</td>
+                                            <td>{sale.invoice_number}</td>
+                                            <td>{sale.customer_name}</td>
+                                            <td className="text-end">{formatCurrency(sale.total_amount)}</td>
+                                        </tr>
+                                        <Collapse in={openRows[sale.id]}>
+                                            <tr>
+                                                <td colSpan="5">
+                                                    <Card className="m-2">
+                                                        <Card.Body>
+                                                            <h5>Sale Items</h5>
+                                                            <Table size="sm">
+                                                                <thead>
+                                                                    <tr>
+                                                                        <th>Product</th>
+                                                                        <th>Quantity</th>
+                                                                        <th>Unit Price</th>
+                                                                        <th className="text-end">Line Total</th>
+                                                                    </tr>
+                                                                </thead>
+                                                                <tbody>
+                                                                    {sale.items.map(item => (
+                                                                        <tr key={item.id}>
+                                                                            <td>{item.product_name}</td>
+                                                                            <td>{item.quantity}</td>
+                                                                            <td>{formatCurrency(item.unit_price)}</td>
+                                                                            <td className="text-end">{formatCurrency(item.line_total)}</td>
+                                                                        </tr>
+                                                                    ))}
+                                                                </tbody>
+                                                            </Table>
+                                                        </Card.Body>
+                                                    </Card>
+                                                </td>
+                                            </tr>
+                                        </Collapse>
+                                    </React.Fragment>
+                                ))}
+                            </tbody>
+                        </Table>
+                    </div>
+                )}
+            </Card.Body>
+        </Card>
+    );
+}
+
+export default SalesReportPage;


### PR DESCRIPTION
This commit introduces a new sales report feature to the application.

The backend is updated with a new API endpoint `/api/reports/sales/` that returns a list of sales within a specified date range. The sales data includes nested sale items.

The frontend now has a new "Sales Report" page that allows users to select a date range and view the corresponding sales data. The report is displayed in a table with expandable rows to show the details of each sale. A link to the new report has been added to the main navigation menu.