### PR TITLE
Enable offer creation from customer detail page

### DIFF
--- a/frontend/src/pages/CustomerDetailPage.js
+++ b/frontend/src/pages/CustomerDetailPage.js
@@ -136,7 +136,13 @@ function CustomerDetailPage() {
             {/* Action Buttons */}
             <ButtonToolbar className="mb-3">
                 <Button variant="primary" className="me-2" onClick={() => navigate(`/customers/${customer.id}/new-sale`)}>Make Sale</Button>
-                <Button variant="secondary" className="me-2" disabled>Prepare Offer</Button>
+                <Button
+                    variant="secondary"
+                    className="me-2"
+                    onClick={() => navigate(`/customers/${customer.id}/new-sale?type=offer`)}
+                >
+                    Make Offer
+                </Button>
                 <Button variant="success" className="me-2" onClick={() => setShowPaymentModal(true)}>Collection / Payment</Button>
             </ButtonToolbar>
 

--- a/frontend/src/pages/SaleFormPage.js
+++ b/frontend/src/pages/SaleFormPage.js
@@ -1,7 +1,7 @@
 // frontend/src/pages/SaleFormPage.js
 
 import React, { useState, useEffect } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import axiosInstance from '../utils/axiosInstance';
 import { Container, Card, Form, Button, Row, Col, Table, InputGroup } from 'react-bootstrap';
 import { Trash } from 'react-bootstrap-icons';
@@ -9,6 +9,8 @@ import { Trash } from 'react-bootstrap-icons';
 function SaleFormPage() {
     const { customerId } = useParams();
     const navigate = useNavigate();
+    const location = useLocation();
+    const isOffer = new URLSearchParams(location.search).get('type') === 'offer';
 
     const [customer, setCustomer] = useState(null);
     const [allProducts, setAllProducts] = useState([]);
@@ -63,6 +65,9 @@ function SaleFormPage() {
             sale_date: saleDate,
             items: lineItems.filter(item => item.product_id) // Filter out empty lines
         };
+        if (isOffer) {
+            saleData.status = 'offer';
+        }
         try {
             await axiosInstance.post('/sales/', saleData);
             navigate(`/customers/${customerId}`); // Redirect back to customer detail
@@ -76,7 +81,7 @@ function SaleFormPage() {
     return (
         <Container>
             <Card>
-                <Card.Header as="h4">New Sale for {customer.name}</Card.Header>
+                <Card.Header as="h4">{isOffer ? `New Offer for ${customer.name}` : `New Sale for ${customer.name}`}</Card.Header>
                 <Card.Body>
                     <Form onSubmit={handleSubmit}>
                         <Row className="mb-3">
@@ -123,7 +128,7 @@ function SaleFormPage() {
                         </div>
                         
                         <div className="mt-4">
-                            <Button variant="success" type="submit">Save Sale</Button>
+                            <Button variant="success" type="submit">{isOffer ? 'Save Offer' : 'Save Sale'}</Button>
                             <Button variant="light" className="ms-2" onClick={() => navigate(`/customers/${customerId}`)}>Cancel</Button>
                         </div>
                     </Form>


### PR DESCRIPTION
## Summary
- enable Make Offer button on customer detail page to open sale form in offer mode
- allow sale form to handle offer mode and post with offer status

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68a45bdf26548323808003beac26dd8f