### PR TITLE
Add offer management frontend pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
-frontend/
 backend/venv/
 backend/__pycache__/

--- a/frontend/src/pages/OfferDetailPage.js
+++ b/frontend/src/pages/OfferDetailPage.js
@@ -1,0 +1,119 @@
+import React, { useState, useEffect } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import axiosInstance from '../utils/axiosInstance';
+import { Card, Button, Spinner, Alert, Row, Col, Table } from 'react-bootstrap';
+
+function OfferDetailPage() {
+    const { id } = useParams();
+    const navigate = useNavigate();
+    const [offer, setOffer] = useState(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState('');
+
+    const fetchOfferData = async () => {
+        setLoading(true);
+        try {
+            const response = await axiosInstance.get(`/offers/${id}/`);
+            setOffer(response.data);
+            setError('');
+        } catch (error) {
+            console.error('Failed to fetch offer data:', error);
+            setError('Could not load offer details.');
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        fetchOfferData();
+    },[id]);
+
+    const handleConvertToSale = async () => {
+        if (window.confirm('Are you sure you want to convert this offer to a sale? This action cannot be undone.')) {
+            try {
+                const response = await axiosInstance.post(`/offers/${id}/convert_to_sale/`);
+                alert('Offer converted to sale successfully.');
+                navigate(`/sales/${response.data.sale_id}`);
+            } catch (err) {
+                console.error('Failed to convert offer to sale:', err);
+                setError('Could not convert the offer. Please try again.');
+            }
+        }
+    };
+
+    if (loading) {
+        return <div className="text-center"><Spinner animation="border" /></div>;
+    }
+
+    if (error) {
+        return <Alert variant="danger">{error}</Alert>;
+    }
+
+    return (
+        <div>
+            <Button variant="secondary" onClick={() => navigate('/offers')} className="mb-3">
+                &larr; Back to Offers List
+            </Button>
+            {offer && (
+                <Card>
+                    <Card.Header>
+                        <h4>Offer #{offer.id}</h4>
+                    </Card.Header>
+                    <Card.Body>
+                        <Row className="mb-4">
+                            <Col md={6}>
+                                <h5>Customer Details:</h5>
+                                <p><strong>Name:</strong> {offer.customer_name}</p>
+                            </Col>
+                            <Col md={6} className="text-md-end">
+                                <h5>Offer Information:</h5>
+                                <p><strong>Offer Date:</strong> {new Date(offer.offer_date).toLocaleDateString()}</p>
+                                <p><strong>Status:</strong> {offer.status}</p>
+                            </Col>
+                        </Row>
+
+                        <h5>Items</h5>
+                        <Table striped bordered hover responsive>
+                            <thead>
+                                <tr>
+                                    <th>#</th><th>Product</th><th>Quantity</th><th>Unit Price</th><th>Line Total</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {offer.items.map((item, index) => (
+                                    <tr key={item.id}>
+                                        <td>{index + 1}</td>
+                                        <td>{item.product_name}</td>
+                                        <td>{item.quantity}</td>
+                                        <td>${parseFloat(item.unit_price).toFixed(2)}</td>
+                                        <td>${(item.quantity * item.unit_price).toFixed(2)}</td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </Table>
+
+                        <hr />
+
+                        <Row className="mt-4">
+                            <Col md={12} className="text-end">
+                                <h4 className="mb-0">
+                                    <strong>Total:</strong>
+                                    <span className="float-end">${parseFloat(offer.total_amount).toFixed(2)}</span>
+                                </h4>
+                            </Col>
+                        </Row>
+                    </Card.Body>
+                    <Card.Footer className="text-end">
+                        {offer.status === 'pending' && (
+                            <Button variant="success" onClick={handleConvertToSale}>
+                                Convert to Sale
+                            </Button>
+                        )}
+                    </Card.Footer>
+                </Card>
+            )}
+        </div>
+    );
+}
+
+export default OfferDetailPage;

--- a/frontend/src/pages/OfferListPage.js
+++ b/frontend/src/pages/OfferListPage.js
@@ -1,0 +1,84 @@
+import React, { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
+import axiosInstance from '../utils/axiosInstance';
+import { Card, Button, Table, Alert, Spinner } from 'react-bootstrap';
+
+function OfferListPage() {
+    const [offers, setOffers] = useState([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState('');
+
+    useEffect(() => {
+        const fetchOffers = async () => {
+            try {
+                setLoading(true);
+                const response = await axiosInstance.get('/offers/');
+                setOffers(response.data);
+                setError('');
+            } catch (err) {
+                console.error("Failed to fetch offers:", err);
+                setError('Could not retrieve offers data.');
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        fetchOffers();
+    }, []);
+
+    if (loading) {
+        return <Spinner animation="border" />;
+    }
+
+    return (
+        <Card>
+            <Card.Header className="d-flex justify-content-between align-items-center">
+                <h4>Offers</h4>
+                <Button as={Link} to="/sales/new" variant="primary">
+                    + New Offer
+                </Button>
+            </Card.Header>
+            <Card.Body>
+                {error && <Alert variant="danger">{error}</Alert>}
+                <Table striped bordered hover responsive>
+                    <thead>
+                        <tr>
+                            <th>#</th>
+                            <th>Offer No.</th>
+                            <th>Customer</th>
+                            <th>Date</th>
+                            <th>Status</th>
+                            <th>Total Amount</th>
+                            <th>Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {offers.length > 0 ? (
+                            offers.map((offer, index) => (
+                                <tr key={offer.id}>
+                                    <td>{index + 1}</td>
+                                    <td>{`OFFER-${offer.id}`}</td>
+                                    <td>{offer.customer_name}</td>
+                                    <td>{new Date(offer.offer_date).toLocaleDateString()}</td>
+                                    <td>{offer.status}</td>
+                                    <td>${parseFloat(offer.total_amount).toFixed(2)}</td>
+                                    <td>
+                                        <Button as={Link} to={`/offers/${offer.id}`} variant="info" size="sm">
+                                        View
+                                    </Button>
+                                    </td>
+                                </tr>
+                            ))
+                        ) : (
+                            <tr>
+                                <td colSpan="7" className="text-center">No offers found.</td>
+                            </tr>
+                        )}
+                    </tbody>
+                </Table>
+            </Card.Body>
+        </Card>
+    );
+}
+
+export default OfferListPage;

--- a/frontend/src/pages/TransactionPage.js
+++ b/frontend/src/pages/TransactionPage.js
@@ -1,0 +1,216 @@
+import React, { useState, useEffect } from 'react';
+import axiosInstance from '../utils/axiosInstance';
+import { useNavigate } from 'react-router-dom';
+import { Form, Button, Card, Row, Col, Table, Alert } from 'react-bootstrap';
+import { FaTrash } from 'react-icons/fa';
+
+function TransactionPage() {
+    // State for data fetched from the API
+    const [customers, setCustomers] = useState([]);
+    const [products, setProducts] = useState([]);
+
+    // State for the form data
+    const [customerId, setCustomerId] = useState('');
+    const [saleItems, setSaleItems] = useState([
+        { product_id: '', quantity: 1, unit_price: '' }
+    ]);
+    
+    // State for UI feedback
+    const [error, setError] = useState('');
+    const navigate = useNavigate();
+
+    // Fetch customers and products when the component loads
+    useEffect(() => {
+        const fetchData = async () => {
+            try {
+                const customerRes = await axiosInstance.get('/customers/');
+                setCustomers(customerRes.data);
+
+                const productRes = await axiosInstance.get('/products/');
+                setProducts(productRes.data);
+            } catch (err) {
+                setError('Failed to load customers or products.');
+            }
+        };
+        fetchData();
+    }, []);
+
+    // Handle changes in the sale item rows
+    const handleItemChange = (index, event) => {
+        const values = [...saleItems];
+        const { name, value } = event.target;
+        
+        values[index][name] = value;
+
+        // If the product is changed, update its unit_price
+        if (name === 'product_id') {
+            const selectedProduct = products.find(p => p.id.toString() === value);
+            values[index]['unit_price'] = selectedProduct ? selectedProduct.sale_price : '';
+        }
+
+        setSaleItems(values);
+    };
+    
+    // Add a new empty row for a sale item
+    const handleAddItem = () => {
+        setSaleItems([...saleItems, { product_id: '', quantity: 1, unit_price: '' }]);
+    };
+
+    // Remove a sale item row
+    const handleRemoveItem = (index) => {
+        const values = [...saleItems];
+        values.splice(index, 1);
+        setSaleItems(values);
+    };
+
+    // Calculate the total amount of the sale
+    const calculateTotal = () => {
+        return saleItems.reduce((total, item) => {
+            return total + (Number(item.quantity) * Number(item.unit_price));
+        }, 0).toFixed(2);
+    };
+
+    // Handle form submission
+    const handleSubmit = async (event, isOffer = false) => {
+        event.preventDefault();
+        setError('');
+
+        if (!customerId || saleItems.some(item => !item.product_id || item.quantity <= 0)) {
+            setError('Please select a customer and ensure all items have a product and valid quantity.');
+            return;
+        }
+
+        const transactionData = {
+            customer_id: parseInt(customerId),
+            items: saleItems.map(item => ({
+                product_id: parseInt(item.product_id),
+                quantity: parseInt(item.quantity),
+                unit_price: parseFloat(item.unit_price)
+            }))
+        };
+        
+        const url = isOffer ? '/offers/' : '/sales/';
+        const successUrl = isOffer ? '/offers' : '/sales';
+        const errorMessage = isOffer ? 'Failed to create offer. Please check your input.' : 'Failed to create sale. Please check your input.';
+
+        try {
+            await axiosInstance.post(url, transactionData);
+            navigate(successUrl);
+        } catch (err) {
+            console.error(err);
+            setError(errorMessage);
+        }
+    };
+
+    return (
+        <Card>
+            <Card.Header><h4>Create New Transaction</h4></Card.Header>
+            <Card.Body>
+                {error && <Alert variant="danger">{error}</Alert>}
+                <Form>
+                    <Row className="mb-3">
+                        <Form.Group as={Col} controlId="formCustomer">
+                            <Form.Label>Customer</Form.Label>
+                            <Form.Select
+                                value={customerId}
+                                onChange={(e) => setCustomerId(e.target.value)}
+                                required
+                            >
+                                <option value="">Select a Customer</option>
+                                {customers.map(customer => (
+                                    <option key={customer.id} value={customer.id}>
+                                        {customer.name}
+                                    </option>
+                                ))}
+                            </Form.Select>
+                        </Form.Group>
+                    </Row>
+
+                      <h5>Sale Items</h5>
+                      <Table bordered hover responsive>
+                        <thead>
+                            <tr>
+                                <th>Product</th>
+                                <th>Quantity</th>
+                                <th>Unit Price</th>
+                                <th>Line Total</th>
+                                <th>Action</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {saleItems.map((item, index) => (
+                                <tr key={index}>
+                                    <td>
+                                        <Form.Select
+                                            name="product_id"
+                                            value={item.product_id}
+                                            onChange={e => handleItemChange(index, e)}
+                                            required
+                                        >
+                                            <option value="">Select a Product</option>
+                                            {products.map(product => (
+                                                <option key={product.id} value={product.id}>
+                                                    {product.name}
+                                                </option>
+                                            ))}
+                                        </Form.Select>
+                                    </td>
+                                    <td>
+                                        <Form.Control
+                                            type="number"
+                                            name="quantity"
+                                            value={item.quantity}
+                                            onChange={e => handleItemChange(index, e)}
+                                            min="1"
+                                            required
+                                        />
+                                    </td>
+                                    <td>
+                                        <Form.Control
+                                            type="number"
+                                            name="unit_price"
+                                            value={item.unit_price}
+                                            onChange={e => handleItemChange(index, e)}
+                                            step="0.01"
+                                            required
+                                        />
+                                    </td>
+                                    <td>
+                                        ${(Number(item.quantity) * Number(item.unit_price)).toFixed(2)}
+                                    </td>
+                                    <td>
+                                        <Button variant="danger" onClick={() => handleRemoveItem(index)}>
+                                            <FaTrash />
+                                        </Button>
+                                    </td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </Table>
+
+                    <Button variant="secondary" onClick={handleAddItem} className="mb-3">
+                        + Add Item
+                    </Button>
+
+                    <div className="text-end">
+                        <h3>Total: ${calculateTotal()}</h3>
+                    </div>
+
+                    <div className="mt-3">
+                        <Button variant="primary" onClick={(e) => handleSubmit(e, false)}>
+                            Create Sale
+                        </Button>
+                        <Button variant="info" className="ms-2" onClick={(e) => handleSubmit(e, true)}>
+                            Create Offer
+                        </Button>
+                        <Button variant="light" className="ms-2" onClick={() => navigate(-1)}>
+                            Cancel
+                        </Button>
+                    </div>
+                </Form>
+            </Card.Body>
+        </Card>
+    );
+}
+
+export default TransactionPage;


### PR DESCRIPTION
## Summary
- track frontend directory in git
- implement TransactionPage for creating sales or offers
- add OfferListPage and OfferDetailPage to view and manage offers

## Testing
- `cd frontend && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a4b55ec9788323907f417b18f189af