### PR TITLE
Fix duplicate created_by in Offer creation

### DIFF
--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -233,7 +233,10 @@ class OfferWriteSerializer(serializers.ModelSerializer):
     def create(self, validated_data):
         items_data = validated_data.pop('items')
         customer_id = validated_data.pop('customer_id')
-        created_by = self.context['request'].user
+        # ``created_by`` may be supplied via ``serializer.save``; pop it to
+        # avoid passing multiple values to ``Offer.objects.create``. Defaults
+        # to the request user.
+        created_by = validated_data.pop('created_by', self.context['request'].user)
 
         with transaction.atomic():
             customer = Customer.objects.get(id=customer_id, created_by=created_by)


### PR DESCRIPTION
## Summary
- avoid passing `created_by` twice when creating Offer

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68a4b7f1e4908323b37c4db321e827e0