### PR TITLE
Enable customer-scoped offer creation and fix logging

### DIFF
--- a/backend/api/activity_logger.py
+++ b/backend/api/activity_logger.py
@@ -3,12 +3,16 @@ from django.contrib.contenttypes.models import ContentType
 from django.core import serializers
 from .models import Activity, Sale, Purchase
 
-def log_activity(user, action_type, instance):
+
+def log_activity(user, action_type, instance, description=None):
+    """Record an activity entry.
+
+    By default a generic description is generated.  Callers may supply a
+    custom ``description`` to override it – useful for cases like converting
+    an offer to a sale where additional context is helpful.
     """
-    Logs an activity for a given model instance.
-    For deletions, it stores a JSON representation of the object for restoration.
-    """
-    description = f'{instance.__class__.__name__} {instance} was {action_type}.'
+    if description is None:
+        description = f"{instance.__class__.__name__} {instance} was {action_type}."
     object_repr = ''
 
     if action_type == 'deleted':
@@ -29,5 +33,5 @@ def log_activity(user, action_type, instance):
         description=description,
         content_type=ContentType.objects.get_for_model(instance),
         object_id=instance.pk,
-        object_repr=object_repr
+        object_repr=object_repr,
     )

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -25,6 +25,8 @@ sales_router.register(r'payments', PaymentViewSet, basename='sale-payments')
 # Create a nested router for payments under customers
 customers_router = routers.NestedSimpleRouter(router, r'customers', lookup='customer')
 customers_router.register(r'payments', CustomerPaymentViewSet, basename='customer-payments')
+# Allow creating and listing offers scoped to a specific customer
+customers_router.register(r'offers', OfferViewSet, basename='customer-offers')
 
 router.register(r'expense-categories', ExpenseCategoryViewSet, basename='expense-category') # <-- Add this
 router.register(r'expenses', ExpenseViewSet, basename='expense')

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -255,8 +255,20 @@ class OfferViewSet(viewsets.ModelViewSet):
             return OfferWriteSerializer
         return OfferReadSerializer
 
+    def get_serializer_context(self):
+        """Include ``customer_id`` when using nested customer routes."""
+        context = super().get_serializer_context()
+        customer_pk = self.kwargs.get('customer_pk')
+        if customer_pk is not None:
+            context['customer_id'] = customer_pk
+        return context
+
     def get_queryset(self):
-        return Offer.objects.filter(created_by=self.request.user).order_by('-offer_date')
+        queryset = Offer.objects.filter(created_by=self.request.user).order_by('-offer_date')
+        customer_pk = self.kwargs.get('customer_pk')
+        if customer_pk is not None:
+            queryset = queryset.filter(customer_id=customer_pk)
+        return queryset
 
     def perform_create(self, serializer):
         instance = serializer.save(created_by=self.request.user)


### PR DESCRIPTION
## Summary
- allow offers to be created through `/customers/<id>/offers/`
- support optional custom descriptions in `log_activity`
- ensure converting an offer to a sale records activities correctly

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68a4ba034030832387720a30447ffd9a