### PR TITLE
Fix missing closing td tag in supplier list page

### DIFF
--- a/frontend/src/pages/SupplierListPage.js
+++ b/frontend/src/pages/SupplierListPage.js
@@ -90,7 +90,7 @@ function SupplierListPage() {
                             <tr>
                                 <td colSpan="2" className="text-center p-5">
                                     {searchTerm ? `No suppliers found for "${searchTerm}".` : 'No suppliers found. Click "Add New Supplier" to get started.'}
-                                d>
+                                </td>
                             </tr>
                         )}
                     </tbody>


### PR DESCRIPTION
## Summary
- fix JSX closing tag in SupplierListPage

## Testing
- `node node_modules/react-scripts/bin/react-scripts.js test --watchAll=false`
- `node node_modules/react-scripts/bin/react-scripts.js build`

------
https://chatgpt.com/codex/tasks/task_e_68a76d6a7d4083239fc71edcc5662e13