### PR TITLE
Add supplier form and routing

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -15,6 +15,7 @@ import ProductFormPage from './pages/ProductFormPage';
 import SaleFormPage from './pages/SaleFormPage';
 import SupplierListPage from './pages/SupplierListPage';
 import SupplierDetailPage from './pages/SupplierDetailPage';
+import SupplierFormPage from './pages/SupplierFormPage';
 import SaleListPage from './pages/SaleListPage'; // <-- Import
 import TransactionPage from './pages/TransactionPage';   // <-- Import
 import SaleDetailPage from './pages/SaleDetailPage';
@@ -56,6 +57,8 @@ function App() {
                   <Route path="inventory/edit/:id" element={<ProductFormPage />} /> {/* <-- Add Route */}
                   <Route path="customers/:customerId/new-sale" element={<SaleFormPage />} />
                   <Route path="suppliers" element={<SupplierListPage />} />
+                  <Route path="suppliers/new" element={<SupplierFormPage />} />
+                  <Route path="suppliers/edit/:id" element={<SupplierFormPage />} />
                   <Route path="suppliers/:id" element={<SupplierDetailPage />} />
                   <Route path="suppliers/:supplierId/new-purchase" element={<PurchaseFormPage />} />
                   <Route path="sales" element={<SaleListPage />} />

--- a/frontend/src/pages/SupplierFormPage.js
+++ b/frontend/src/pages/SupplierFormPage.js
@@ -1,0 +1,100 @@
+// frontend/src/pages/SupplierFormPage.js
+
+import React, { useState, useEffect } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import axiosInstance from '../utils/axiosInstance';
+import { Container, Card, Form, Button, Alert } from 'react-bootstrap';
+
+function SupplierFormPage() {
+    const { id } = useParams();
+    const navigate = useNavigate();
+    const isEditing = Boolean(id);
+
+    const [formData, setFormData] = useState({
+        name: '',
+        email: '',
+        phone: '',
+        address: '',
+        open_balance: 0.0,
+    });
+    const [error, setError] = useState('');
+    const [success, setSuccess] = useState('');
+
+    useEffect(() => {
+        if (isEditing) {
+            const fetchSupplier = async () => {
+                try {
+                    const response = await axiosInstance.get(`/suppliers/${id}/`);
+                    setFormData(response.data);
+                } catch (error) {
+                    setError('Failed to fetch supplier details.');
+                }
+            };
+            fetchSupplier();
+        }
+    }, [id, isEditing]);
+
+    const handleChange = (e) => {
+        setFormData({ ...formData, [e.target.name]: e.target.value });
+    };
+
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+
+        const apiCall = isEditing
+            ? axiosInstance.patch(`/suppliers/${id}/`, formData)
+            : axiosInstance.post('/suppliers/', formData);
+
+        try {
+            await apiCall;
+            setSuccess(`Supplier successfully ${isEditing ? 'updated' : 'created'}!`);
+            setTimeout(() => navigate('/suppliers'), 1500);
+        } catch (error) {
+            setError('Failed to save supplier. Check all required fields.');
+            console.error('API Error:', error.response?.data);
+        }
+    };
+
+    return (
+        <Container>
+            <Form onSubmit={handleSubmit}>
+                <Card>
+                    <Card.Header className="d-flex justify-content-between">
+                        <h4>{isEditing ? `Edit Supplier: ${formData.name}` : 'New Supplier'}</h4>
+                        <div>
+                            <Button variant="success" type="submit" className="me-2">Save</Button>
+                            <Button variant="secondary" onClick={() => navigate('/suppliers')}>Go Back</Button>
+                        </div>
+                    </Card.Header>
+                    <Card.Body>
+                        {error && <Alert variant="danger">{error}</Alert>}
+                        {success && <Alert variant="success">{success}</Alert>}
+                        <Form.Group className="mb-3">
+                            <Form.Label>Name <span className="text-danger">*</span></Form.Label>
+                            <Form.Control type="text" name="name" value={formData.name} onChange={handleChange} required />
+                        </Form.Group>
+                        <Form.Group className="mb-3">
+                            <Form.Label>Email</Form.Label>
+                            <Form.Control type="email" name="email" value={formData.email} onChange={handleChange} />
+                        </Form.Group>
+                        <Form.Group className="mb-3">
+                            <Form.Label>Phone</Form.Label>
+                            <Form.Control type="text" name="phone" value={formData.phone} onChange={handleChange} />
+                        </Form.Group>
+                        <Form.Group className="mb-3">
+                            <Form.Label>Address</Form.Label>
+                            <Form.Control as="textarea" rows={3} name="address" value={formData.address} onChange={handleChange} />
+                        </Form.Group>
+                        <Form.Group>
+                            <Form.Label>Opening Balance</Form.Label>
+                            <Form.Control type="number" step="0.01" name="open_balance" value={formData.open_balance} onChange={handleChange} />
+                        </Form.Group>
+                    </Card.Body>
+                </Card>
+            </Form>
+        </Container>
+    );
+}
+
+export default SupplierFormPage;
+


### PR DESCRIPTION
## Summary
- add supplier creation/edit form page
- wire up supplier routes for new and edit to use the new form

## Testing
- `python manage.py test`
- `npm test -- --watchAll=false` *(fails: react-scripts: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_68a8192a8c048323b09abcff2d158c91