### PR TITLE
fix: handle NaN open balance

### DIFF
--- a/frontend/src/pages/CustomerDetailPage.js
+++ b/frontend/src/pages/CustomerDetailPage.js
@@ -70,7 +70,8 @@ function CustomerDetailPage() {
     };
     
     const formatCurrency = (amount, currency) => {
-        return new Intl.NumberFormat('en-US', { style: 'currency', currency: currency || 'USD' }).format(amount);
+        const value = isNaN(Number(amount)) ? 0 : Number(amount);
+        return new Intl.NumberFormat('en-US', { style: 'currency', currency: currency || 'USD' }).format(value);
     };
 
     const renderSummaryCard = (bg, title, amount, Icon) => (
@@ -86,19 +87,20 @@ function CustomerDetailPage() {
     );
 
     const renderOpenBalanceCard = (balance, currency) => {
+        const numericBalance = isNaN(Number(balance)) ? 0 : Number(balance);
         let cardProps;
 
-        if (balance > 0) {
+        if (numericBalance > 0) {
             cardProps = {
                 bg: 'danger',
                 title: 'Customer Debt',
-                amount: formatCurrency(balance, currency)
+                amount: formatCurrency(numericBalance, currency)
             };
-        } else if (balance < 0) {
+        } else if (numericBalance < 0) {
             cardProps = {
                 bg: 'success',
                 title: 'Extra Money (Credit)',
-                amount: formatCurrency(Math.abs(balance), currency)
+                amount: formatCurrency(Math.abs(numericBalance), currency)
             };
         } else {
             cardProps = {

--- a/frontend/src/pages/CustomerListPage.js
+++ b/frontend/src/pages/CustomerListPage.js
@@ -48,7 +48,8 @@ function CustomerListPage() {
     };
 
     const formatCurrency = (amount, currency) => {
-        return new Intl.NumberFormat('en-US', { style: 'currency', currency: currency }).format(amount);
+        const value = isNaN(Number(amount)) ? 0 : Number(amount);
+        return new Intl.NumberFormat('en-US', { style: 'currency', currency: currency }).format(value);
     };
 
     return (


### PR DESCRIPTION
## Summary
- avoid NaN rendering by defaulting invalid customer balances to zero in lists
- ensure customer detail open balance card interprets invalid balances as zero

## Testing
- `node node_modules/react-scripts/bin/react-scripts.js test --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68aa08b388108323b4bbd2b4d5ff3fd3