### PR TITLE
Remove stray import from backend tests

### DIFF
--- a/backend/api/tests.py
+++ b/backend/api/tests.py
@@ -18,7 +18,6 @@ from .models import (
     OfferItem,
     Sale,
     SaleItem,
- main
 )
 from .serializers import ProductSerializer, PaymentSerializer
 from .activity_logger import log_activity


### PR DESCRIPTION
## Summary
- fix ImportError in API tests by removing nonexistent `main` import

## Testing
- `cd backend && python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68ad8d4de5448323ae2129ddacdb6b0f