### PR TITLE
Revamp dashboard overview

### DIFF
--- a/frontend/src/components/BankAccountsOverview.js
+++ b/frontend/src/components/BankAccountsOverview.js
@@ -1,0 +1,71 @@
+import React, { useEffect, useState } from 'react';
+import { Table, Spinner, Alert } from 'react-bootstrap';
+import axiosInstance from '../utils/axiosInstance';
+
+function BankAccountsOverview() {
+  const [accounts, setAccounts] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    const fetchAccounts = async () => {
+      try {
+        const res = await axiosInstance.get('/accounts/');
+        setAccounts(res.data);
+      } catch (err) {
+        setError('Could not load bank accounts.');
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchAccounts();
+  }, []);
+
+  if (loading) {
+    return <div className="text-center"><Spinner animation="border" /></div>;
+  }
+
+  if (error) {
+    return <Alert variant="danger">{error}</Alert>;
+  }
+
+  const totals = accounts.reduce((acc, account) => {
+    const currency = account.currency;
+    const amount = parseFloat(account.balance);
+    acc[currency] = (acc[currency] || 0) + amount;
+    return acc;
+  }, {});
+
+  return (
+    <div className="mt-5">
+      <h4>Bank Accounts</h4>
+      <div className="mb-3">
+        {Object.entries(totals).map(([currency, amount]) => (
+          <span key={currency} className="me-3 fw-bold">
+            {currency}: {amount.toFixed(2)}
+          </span>
+        ))}
+      </div>
+      <Table striped bordered hover>
+        <thead>
+          <tr>
+            <th>Account</th>
+            <th>Balance</th>
+            <th>Currency</th>
+          </tr>
+        </thead>
+        <tbody>
+          {accounts.map(account => (
+            <tr key={account.id}>
+              <td>{account.name}</td>
+              <td>{parseFloat(account.balance).toFixed(2)}</td>
+              <td>{account.currency}</td>
+            </tr>
+          ))}
+        </tbody>
+      </Table>
+    </div>
+  );
+}
+
+export default BankAccountsOverview;

--- a/frontend/src/pages/DashboardPage.css
+++ b/frontend/src/pages/DashboardPage.css
@@ -46,24 +46,3 @@
         font-size: 1.3rem;
     }
 }
-
-.chart-container {
-    position: relative;
-    margin: auto;
-    height: 60vh;
-    width: 80vw;
-}
-
-@media (max-width: 768px) {
-    .chart-container {
-        height: 50vh;
-        width: 90vw;
-    }
-}
-
-@media (max-width: 576px) {
-    .chart-container {
-        height: 40vh;
-        width: 100vw;
-    }
-}

--- a/frontend/src/pages/DashboardPage.js
+++ b/frontend/src/pages/DashboardPage.js
@@ -3,21 +3,10 @@ import './DashboardPage.css';
 import React, { useState, useEffect } from 'react';
 import { Card, Row, Col, Spinner, Alert } from 'react-bootstrap';
 import axiosInstance from '../utils/axiosInstance';
-import { FaUsers, FaDollarSign, FaBoxOpen, FaCreditCard } from 'react-icons/fa';
-import { Bar } from 'react-chartjs-2';
+import { FaUsers, FaDollarSign, FaBoxOpen, FaCreditCard, FaMoneyBillWave } from 'react-icons/fa';
 import RecentActivities from '../components/RecentActivities';
-import {
-    Chart as ChartJS,
-    CategoryScale,
-    LinearScale,
-    BarElement,
-    Title,
-    Tooltip,
-    Legend,
-} from 'chart.js';
+import BankAccountsOverview from '../components/BankAccountsOverview';
 // frontend/src/pages/DashboardPage.js
-
-ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend);
 
 
 
@@ -40,29 +29,6 @@ function DashboardPage() {
     const [summary, setSummary] = useState(null);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState('');
-
-    const barData = summary ? {
-        labels: ['Receivables', 'Stock Value', 'Expenses'],
-        datasets: [
-            {
-                label: 'Amount ($)',
-                data: [
-                    parseFloat(summary.total_receivables),
-                    parseFloat(summary.stock_value),
-                    parseFloat(summary.expenses)
-                ],
-                backgroundColor: ['#0d6efd', '#0dcaf0', '#dc3545'],
-            },
-        ],
-    } : null;
-
-    const barOptions = {
-        responsive: true,
-        plugins: {
-            legend: { position: 'top' },
-            title: { display: true, text: 'Financial Overview' },
-        },
-    };
 
     useEffect(() => {
         const fetchSummaryData = async () => {
@@ -94,6 +60,24 @@ function DashboardPage() {
             <h2 className="mb-4">Dashboard</h2>
             {summary && (
                 <>
+                    <Row className="g-4 justify-content-end mb-4">
+                        <Col md={6} lg={3}>
+                            <SummaryCard
+                                title="Today's Sales"
+                                value={`$${parseFloat(summary.today_sales).toFixed(2)}`}
+                                icon={<FaDollarSign size={50} />}
+                                color="secondary"
+                            />
+                        </Col>
+                        <Col md={6} lg={3}>
+                            <SummaryCard
+                                title="Incoming Money"
+                                value={`$${parseFloat(summary.today_incoming).toFixed(2)}`}
+                                icon={<FaMoneyBillWave size={50} />}
+                                color="warning"
+                            />
+                        </Col>
+                    </Row>
                     <Row className="g-4">
                         <Col md={6} lg={4}>
                             <SummaryCard
@@ -128,11 +112,7 @@ function DashboardPage() {
                             />
                         </Col>
                     </Row>
-                    {barData && (
-                        <div className="chart-container mt-5">
-                            <Bar data={barData} options={barOptions} />
-                        </div>
-                    )}
+                    <BankAccountsOverview />
                     <RecentActivities />
                 </>
             )}


### PR DESCRIPTION
## Summary
- replace financial overview chart with daily sales and incoming money cards
- add bank accounts overview table with currency totals
- expose today's sales and incoming amounts in dashboard summary API

## Testing
- `python manage.py test`
- `npm test --silent -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b498546634832388a1bd28bf8c942d