### PR TITLE
feat: add progress-based dashboard

### DIFF
--- a/frontend/src/pages/DashboardPage.css
+++ b/frontend/src/pages/DashboardPage.css
@@ -1,13 +1,8 @@
-.summary-card {
-    transition: transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
+.progress-card .progress {
+    height: 8px;
 }
 
-.summary-card:hover {
-    transform: translateY(-5px);
-    box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15) !important;
+.progress-card .card-header {
+    font-weight: 600;
 }
 
-.icon {
-    font-size: 2.5rem;
-    margin-right: 1rem;
-}


### PR DESCRIPTION
## Summary
- replace grid of summary cards with progress-based dashboard sections for assets, liabilities and performance
- show current date on dashboard
- add lightweight styles for progress-card headers and progress bars

## Testing
- `cd frontend && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68ba6965249883239d706d91f9e06f27