### PR TITLE
Support buying from customers

### DIFF
--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -59,14 +59,17 @@ class Customer(models.Model):
 
     @property
     def balance(self):
-        """Current balance derived from sales and payments."""
+        """Current balance derived from sales, purchases, and payments."""
         sales_total = self.sales.aggregate(
             total=Coalesce(Sum('total_amount'), 0, output_field=DecimalField())
         )['total']
         payments_total = self.payments.aggregate(
             total=Coalesce(Sum('converted_amount'), 0, output_field=DecimalField())
         )['total']
-        return sales_total - payments_total
+        purchases_total = self.purchases.aggregate(
+            total=Coalesce(Sum('total_amount'), 0, output_field=DecimalField())
+        )['total']
+        return sales_total - payments_total - purchases_total
 
 
 class Sale(models.Model):

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -57,6 +57,7 @@ function App() {
                   <Route path="inventory/new" element={<ProductFormPage />} /> {/* <-- Add Route */}
                   <Route path="inventory/edit/:id" element={<ProductFormPage />} /> {/* <-- Add Route */}
                   <Route path="customers/:customerId/new-sale" element={<SaleFormPage />} />
+                  <Route path="customers/:customerId/new-purchase" element={<PurchaseFormPage />} />
                   <Route path="suppliers" element={<SupplierListPage />} />
                   <Route path="suppliers/new" element={<SupplierFormPage />} />
                   <Route path="suppliers/edit/:id" element={<SupplierFormPage />} />

--- a/frontend/src/pages/CustomerDetailPage.js
+++ b/frontend/src/pages/CustomerDetailPage.js
@@ -172,6 +172,13 @@ function CustomerDetailPage() {
                 >
                     Make Offer
                 </Button>
+                <Button
+                    variant="warning"
+                    className="me-2"
+                    onClick={() => navigate(`/customers/${customer.id}/new-purchase`)}
+                >
+                    Buy from Customer
+                </Button>
                 <Button variant="success" className="me-2" onClick={() => setShowPaymentModal(true)}>Collection / Payment</Button>
             </ButtonToolbar>
 


### PR DESCRIPTION
## Summary
- allow purchases from customers via dedicated route and button
- generalize purchase form to handle customer or supplier
- ensure customer balance includes purchases

## Testing
- `python manage.py test`
- `node node_modules/react-scripts/bin/react-scripts.js test --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68ba7430160883239c064bc82182e7bd