### PR TITLE
Rearrange supplier detail cards

### DIFF
--- a/frontend/src/pages/SupplierDetailPage.js
+++ b/frontend/src/pages/SupplierDetailPage.js
@@ -189,7 +189,7 @@ function SupplierDetailPage() {
 
             {/* Transaction Lists */}
             <Row>
-                <Col md={4}>
+                <Col md={6}>
                     <Card>
                         <Card.Header as="h5">Previous Purchases</Card.Header>
                         <Card.Body>
@@ -233,9 +233,8 @@ function SupplierDetailPage() {
                             </Accordion>
                         </Card.Body>
                     </Card>
-                </Col>
-                <Col md={4}>
-                    <Card>
+
+                    <Card className="mt-3">
                         <Card.Header as="h5">Previous Sales</Card.Header>
                         <Card.Body>
                             <Accordion>
@@ -279,8 +278,8 @@ function SupplierDetailPage() {
                         </Card.Body>
                     </Card>
                 </Col>
-                <Col md={4}>
-                     <Card>
+                <Col md={6}>
+                    <Card>
                         <Card.Header as="h5">Previous Payments</Card.Header>
                         <Card.Body>
                             <Accordion>


### PR DESCRIPTION
## Summary
- Display previous sales directly beneath previous purchases on the supplier detail page.
- Keep payments in a separate column for a cleaner layout.

## Testing
- `npm test -- --watchAll=false`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ba7e5c53208323918eb76b207a436d