### PR TITLE
fix invoice printing to avoid stale content

### DIFF
--- a/frontend/src/pages/SaleDetailPage.js
+++ b/frontend/src/pages/SaleDetailPage.js
@@ -58,11 +58,10 @@ function SaleDetailPage() {
     const handlePrint = () => {
         if (!invoiceRef.current) return;
         const printContents = invoiceRef.current.innerHTML;
-        const printWindow = window.open('', '', 'height=800,width=600');
-        printWindow.document.write('<html><head><title>Sale Invoice</title>');
-        printWindow.document.write('</head><body>');
-        printWindow.document.write(printContents);
-        printWindow.document.write('</body></html>');
+        const printWindow = window.open('', '_blank', 'height=800,width=600');
+        // Ensure a fresh document for each print to avoid caching previous invoice content
+        printWindow.document.open();
+        printWindow.document.write(`<!DOCTYPE html><html><head><title>Sale Invoice</title></head><body>${printContents}</body></html>`);
         printWindow.document.close();
         printWindow.focus();
         printWindow.print();


### PR DESCRIPTION
## Summary
- ensure each invoice print opens a fresh document to avoid reusing previous invoice content

## Testing
- `npm test --silent -- --watchAll=false`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bbdfaa531083238a457741d39134f7