### PR TITLE
Validate product stock during sale creation

### DIFF
--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -206,6 +206,14 @@ class SaleWriteSerializer(serializers.ModelSerializer):
             for item_data in items_data:
                 product_id = item_data.pop('product_id')
                 product = Product.objects.get(id=product_id, created_by=created_by)
+                quantity = Decimal(item_data['quantity'])
+
+                if product.stock_quantity < quantity:
+                    raise serializers.ValidationError(
+                        {
+                            'items': f"Insufficient stock for product '{product.name}'."
+                        }
+                    )
 
                 sale_item = SaleItem.objects.create(
                     sale=sale,

--- a/backend/api/tests/test_invoice_number.py
+++ b/backend/api/tests/test_invoice_number.py
@@ -13,7 +13,10 @@ class InvoiceNumberGenerationTest(TestCase):
         self.user = User.objects.create_user(username="invuser", password="pw")
         self.customer = Customer.objects.create(name="C", created_by=self.user)
         self.product = Product.objects.create(
-            name="P", sale_price=Decimal("10.00"), created_by=self.user
+            name="P",
+            sale_price=Decimal("10.00"),
+            stock_quantity=Decimal("10"),
+            created_by=self.user,
         )
 
     def _get_request(self):

--- a/backend/api/tests/test_invoice_pdf_currency.py
+++ b/backend/api/tests/test_invoice_pdf_currency.py
@@ -52,7 +52,10 @@ class InvoicePDFCurrencyTest(TestCase):
     def setUp(self):
         self.user = User.objects.create_user(username="curuser", password="pw")
         self.product = Product.objects.create(
-            name="Prod", sale_price=Decimal("10.00"), created_by=self.user
+            name="Prod",
+            sale_price=Decimal("10.00"),
+            stock_quantity=Decimal("10"),
+            created_by=self.user,
         )
 
     def _get_request(self):

--- a/backend/api/tests/test_legacy.py
+++ b/backend/api/tests/test_legacy.py
@@ -560,7 +560,12 @@ class SupplierDetailsIncludeSalesTest(TestCase):
         self.client = APIClient()
         self.client.force_authenticate(user=self.user)
         self.supplier = Supplier.objects.create(name='Sup', created_by=self.user)
-        self.product = Product.objects.create(name='Prod', sale_price=Decimal('10.00'), created_by=self.user)
+        self.product = Product.objects.create(
+            name='Prod',
+            sale_price=Decimal('10.00'),
+            stock_quantity=Decimal('10'),
+            created_by=self.user,
+        )
 
         serializer = SaleWriteSerializer(
             data={

--- a/backend/api/tests/test_sale_stock_validation.py
+++ b/backend/api/tests/test_sale_stock_validation.py
@@ -1,0 +1,76 @@
+from datetime import date
+from decimal import Decimal
+
+from django.contrib.auth.models import User
+from django.test import TestCase
+from rest_framework import serializers
+
+from ..models import Customer, Product, Sale
+from ..serializers import SaleWriteSerializer
+
+
+class SaleStockValidationTest(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="stockuser", password="pw")
+        self.customer = Customer.objects.create(name="C", created_by=self.user)
+        self.product = Product.objects.create(
+            name="P",
+            sale_price=Decimal("10.00"),
+            stock_quantity=Decimal("5"),
+            created_by=self.user,
+        )
+
+    def _get_request(self):
+        class DummyRequest:
+            pass
+
+        req = DummyRequest()
+        req.user = self.user
+        return req
+
+    def test_sale_reduces_stock_when_sufficient(self):
+        serializer = SaleWriteSerializer(
+            data={
+                "customer_id": self.customer.id,
+                "sale_date": str(date.today()),
+                "items": [
+                    {
+                        "product_id": self.product.id,
+                        "quantity": 3,
+                        "unit_price": "10.00",
+                    }
+                ],
+            },
+            context={"request": self._get_request()},
+        )
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        sale = serializer.save()
+
+        self.product.refresh_from_db()
+        self.assertEqual(self.product.stock_quantity, Decimal("2"))
+        self.assertEqual(sale.total_amount, Decimal("30.00"))
+
+    def test_sale_fails_when_insufficient_stock(self):
+        serializer = SaleWriteSerializer(
+            data={
+                "customer_id": self.customer.id,
+                "sale_date": str(date.today()),
+                "items": [
+                    {
+                        "product_id": self.product.id,
+                        "quantity": 6,
+                        "unit_price": "10.00",
+                    }
+                ],
+            },
+            context={"request": self._get_request()},
+        )
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+
+        with self.assertRaises(serializers.ValidationError):
+            serializer.save()
+
+        self.product.refresh_from_db()
+        self.assertEqual(self.product.stock_quantity, Decimal("5"))
+        self.assertEqual(Sale.objects.count(), 0)
+


### PR DESCRIPTION
## Summary
- ensure `SaleWriteSerializer` checks each product's stock before reducing quantity
- raise a validation error if an item requests more than available stock
- add tests for successful and failing stock validations

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68bc1518fa1c8323bd3c133bb4dc63dd