### PR TITLE
feat: fetch base currency and auto-convert amounts

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,6 +1,6 @@
 // frontend/src/App.js
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import LoginPage from './pages/LoginPage';
 import RegisterPage from './pages/RegisterPage';
@@ -33,8 +33,13 @@ import OfferDetailPage from './pages/OfferDetailPage';
 import ActivityPage from './pages/ActivityPage';
 import CompanyInfoPage from './pages/CompanyInfoPage';
 
+import { loadBaseCurrency } from './config/currency';
+
 
 function App() {
+  useEffect(() => {
+    loadBaseCurrency();
+  }, []);
   return (
     <BrowserRouter>
       <Routes>

--- a/frontend/src/config/currency.js
+++ b/frontend/src/config/currency.js
@@ -1,0 +1,34 @@
+import axios from 'axios';
+import axiosInstance from '../utils/axiosInstance';
+
+let baseCurrency = 'USD';
+
+export const getBaseCurrency = () => baseCurrency;
+
+export const loadBaseCurrency = async () => {
+  try {
+    const res = await axiosInstance.get('/settings/');
+    if (res.data && res.data.base_currency) {
+      baseCurrency = res.data.base_currency;
+    }
+  } catch (err) {
+    console.error('Failed to fetch base currency', err);
+  }
+  return baseCurrency;
+};
+
+export const fetchExchangeRate = async (from, to) => {
+  if (!from || !to || from === to) {
+    return 1;
+  }
+  try {
+    const res = await axios.get(`https://api.exchangerate.host/convert?from=${from}&to=${to}`);
+    return res.data?.result || 1;
+  } catch (err) {
+    console.error('Failed to fetch exchange rate', err);
+    return 1;
+  }
+};
+
+export const currencyOptions = ['USD', 'EUR', 'KZT', 'TRY'];
+


### PR DESCRIPTION
## Summary
- load company base currency on app init
- show original and base currency values in sale detail views
- add currency selectors and automatic exchange-rate conversion for payment modals

## Testing
- `npm test -- --watchAll=false`
- `python manage.py test` *(fails: Conflicting migrations detected)*

------
https://chatgpt.com/codex/tasks/task_e_68bc29a28d588323afb8034b1d4e7914