### PR TITLE
Add currency conversion tests for payments

### DIFF
--- a/backend/api/tests/test_payment_currency_conversion.py
+++ b/backend/api/tests/test_payment_currency_conversion.py
@@ -1,0 +1,46 @@
+from decimal import Decimal
+from datetime import date
+from unittest.mock import patch
+
+from django.contrib.auth.models import User
+from django.test import TestCase
+
+from ..models import Customer, BankAccount, Payment
+
+
+class PaymentCurrencyConversionTest(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="payer", password="pw")
+        self.customer = Customer.objects.create(
+            name="Alice",
+            currency="USD",
+            open_balance=Decimal("125.00"),
+            created_by=self.user,
+        )
+        self.account = BankAccount.objects.create(
+            name="Euro Account",
+            currency="EUR",
+            created_by=self.user,
+        )
+
+    @patch("api.models.get_exchange_rate", return_value=Decimal("1.25"))
+    def test_foreign_currency_payment_converts_and_updates_balances(self, mock_rate):
+        payment = Payment.objects.create(
+            customer=self.customer,
+            payment_date=date.today(),
+            original_amount=Decimal("100.00"),
+            original_currency="EUR",
+            exchange_rate=Decimal("1.25"),
+            account=self.account,
+            method="Cash",
+            created_by=self.user,
+        )
+
+        payment.refresh_from_db()
+        self.customer.refresh_from_db()
+        self.account.refresh_from_db()
+
+        self.assertEqual(payment.converted_amount, Decimal("125.00"))
+        self.assertEqual(self.account.balance, Decimal("100.00"))
+        self.assertEqual(self.customer.open_balance, Decimal("0.00"))
+        mock_rate.assert_not_called()

--- a/frontend/src/components/CustomerPaymentModal.test.js
+++ b/frontend/src/components/CustomerPaymentModal.test.js
@@ -1,0 +1,56 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import CustomerPaymentModal from './CustomerPaymentModal';
+import axiosInstance from '../utils/axiosInstance';
+
+jest.mock('../utils/axiosInstance', () => ({
+  get: jest.fn(),
+}));
+
+describe('CustomerPaymentModal currency display', () => {
+  const defaultProps = {
+    show: true,
+    handleClose: jest.fn(),
+    customerId: 1,
+    onPaymentAdded: jest.fn(),
+    customerCurrency: 'USD',
+  };
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('shows converted amount when account currency differs', async () => {
+    axiosInstance.get.mockResolvedValueOnce({
+      data: [{ id: 1, name: 'Euro', currency: 'EUR' }],
+    });
+
+    render(<CustomerPaymentModal {...defaultProps} />);
+
+    await waitFor(() => expect(axiosInstance.get).toHaveBeenCalledWith('/accounts/'));
+    await screen.findByText(/Euro \(EUR\)/);
+
+    fireEvent.change(screen.getByLabelText(/account/i), { target: { value: '1' } });
+    fireEvent.change(screen.getByLabelText(/^Amount$/i), { target: { value: '10' } });
+
+    const rateInput = await screen.findByLabelText(/exchange rate/i);
+    fireEvent.change(rateInput, { target: { value: '2' } });
+
+    const converted = await screen.findByLabelText(/converted amount/i);
+    await waitFor(() => expect(converted.value).toBe('20.00'));
+  });
+
+  test('hides exchange fields when currencies match', async () => {
+    axiosInstance.get.mockResolvedValueOnce({
+      data: [{ id: 1, name: 'USD Acc', currency: 'USD' }],
+    });
+
+    render(<CustomerPaymentModal {...defaultProps} />);
+    await waitFor(() => expect(axiosInstance.get).toHaveBeenCalled());
+
+    fireEvent.change(screen.getByLabelText(/account/i), { target: { value: '1' } });
+
+    expect(screen.queryByLabelText(/exchange rate/i)).toBeNull();
+    expect(screen.queryByLabelText(/converted amount/i)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add backend test for foreign-currency payment conversion and balance updates
- add frontend test verifying modal renders and converts amounts for differing currencies

## Testing
- `python manage.py test api/tests/test_payment_currency_conversion.py -q`
- `CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68bc2c2d33e883239b59dbc3e71ead71