### PR TITLE
feat(frontend): configurable API base URL and resilient token decode

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -2,6 +2,10 @@
 
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
+## Environment Variables
+
+The application uses the `REACT_APP_API_BASE_URL` variable to determine the base URL for API requests. If not set, it defaults to `http://127.0.0.1:8000/api`.
+
 ## Available Scripts
 
 In the project directory, you can run:

--- a/frontend/src/utils/axiosInstance.js
+++ b/frontend/src/utils/axiosInstance.js
@@ -4,7 +4,7 @@ import axios from 'axios';
 import { jwtDecode } from 'jwt-decode';
 import dayjs from 'dayjs';
 
-const baseURL = 'http://127.0.0.1:8000/api';
+const baseURL = process.env.REACT_APP_API_BASE_URL || 'http://127.0.0.1:8000/api';
 
 const axiosInstance = axios.create({
     baseURL,
@@ -18,7 +18,15 @@ axiosInstance.interceptors.request.use(async req => {
         return req;
     }
 
-    const user = jwtDecode(accessToken);
+    let user;
+    try {
+        user = jwtDecode(accessToken);
+    } catch (error) {
+        localStorage.removeItem('accessToken');
+        localStorage.removeItem('refreshToken');
+        window.location.href = '/login';
+        return req;
+    }
     const isExpired = dayjs.unix(user.exp).diff(dayjs()) < 1;
 
     if (!isExpired) {


### PR DESCRIPTION
## Summary
- make API base URL configurable via `REACT_APP_API_BASE_URL`
- handle JWT decode errors by clearing tokens and redirecting to login
- document `REACT_APP_API_BASE_URL` in README

## Testing
- `npm test -- --watchAll=false`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68bdbf5bcddc83239d06480742446906