### PR TITLE
fix: use relative supplier API paths

### DIFF
--- a/frontend/src/components/SupplierPaymentModal.js
+++ b/frontend/src/components/SupplierPaymentModal.js
@@ -20,7 +20,7 @@ function SupplierPaymentModal({ show, handleClose, supplierId, onPaymentAdded, p
     useEffect(() => {
         const fetchInitialData = async () => {
             try {
-                const accountsRes = await axiosInstance.get('/accounts/');
+                const accountsRes = await axiosInstance.get('accounts/');
                 setAccounts(accountsRes.data);
 
                 const bc = await loadBaseCurrency();
@@ -107,8 +107,8 @@ function SupplierPaymentModal({ show, handleClose, supplierId, onPaymentAdded, p
 
         try {
             const url = payment
-                ? `/suppliers/${supplierId}/payments/${payment.id}/`
-                : `/suppliers/${supplierId}/payments/`;
+                ? `suppliers/${supplierId}/payments/${payment.id}/`
+                : `suppliers/${supplierId}/payments/`;
             const httpMethod = payment ? 'put' : 'post';
 
             await axiosInstance[httpMethod](url, paymentData);

--- a/frontend/src/pages/EditPurchasePage.js
+++ b/frontend/src/pages/EditPurchasePage.js
@@ -32,7 +32,7 @@ function EditPurchasePage() {
         const fetchInitialData = async () => {
             try {
                 const [suppliersRes, productsRes, accountsRes, purchaseRes] = await Promise.all([
-                    axiosInstance.get('/suppliers/'),
+                    axiosInstance.get('suppliers/'),
                     axiosInstance.get('/products/'),
                     axiosInstance.get('/accounts/'),
                     axiosInstance.get(`/purchases/${id}/`)

--- a/frontend/src/pages/PurchaseFormPage.js
+++ b/frontend/src/pages/PurchaseFormPage.js
@@ -20,7 +20,7 @@ function PurchaseFormPage() {
             try {
                 const [partnerRes, prodRes] = await Promise.all([
                     supplierId
-                        ? axiosInstance.get(`/suppliers/${supplierId}/`)
+                        ? axiosInstance.get(`suppliers/${supplierId}/`)
                         : axiosInstance.get(`/customers/${customerId}/`),
                     axiosInstance.get('/products/')
                 ]);

--- a/frontend/src/pages/PurchaseListPage.js
+++ b/frontend/src/pages/PurchaseListPage.js
@@ -39,7 +39,7 @@ function PurchaseListPage() {
         try {
             const [purchasesRes, suppliersRes, productsRes, accountsRes] = await Promise.all([
                 axiosInstance.get('/purchases/'),
-                axiosInstance.get('/suppliers/'),
+                axiosInstance.get('suppliers/'),
                 axiosInstance.get('/products/'),
                 axiosInstance.get('/accounts/')
             ]);

--- a/frontend/src/pages/SaleFormPage.js
+++ b/frontend/src/pages/SaleFormPage.js
@@ -24,7 +24,7 @@ function SaleFormPage() {
         const fetchData = async () => {
             try {
                 const [custRes, prodRes] = await Promise.all([
-                    axiosInstance.get(isSupplierSale ? `/suppliers/${entityId}/` : `/customers/${entityId}/`),
+                    axiosInstance.get(isSupplierSale ? `suppliers/${entityId}/` : `customers/${entityId}/`),
                     axiosInstance.get('/products/')
                 ]);
                 const entityData = { currency: 'USD', ...custRes.data };

--- a/frontend/src/pages/SupplierDetailPage.js
+++ b/frontend/src/pages/SupplierDetailPage.js
@@ -21,7 +21,7 @@ function SupplierDetailPage() {
 
     const fetchDetails = async () => {
         try {
-            const response = await axiosInstance.get(`/suppliers/${id}/details/`);
+            const response = await axiosInstance.get(`suppliers/${id}/details/`);
             setData(response.data);
         } catch (err) {
             setError('Failed to fetch supplier details.');
@@ -66,7 +66,7 @@ function SupplierDetailPage() {
     const handleDeletePayment = async (paymentId) => {
         if (!window.confirm('Are you sure you want to delete this payment?')) return;
         try {
-            await axiosInstance.delete(`/suppliers/${id}/payments/${paymentId}/`);
+            await axiosInstance.delete(`suppliers/${id}/payments/${paymentId}/`);
             fetchDetails();
         } catch (err) {
             setError('Failed to delete payment.');

--- a/frontend/src/pages/SupplierFormPage.js
+++ b/frontend/src/pages/SupplierFormPage.js
@@ -30,7 +30,7 @@ function SupplierFormPage() {
         if (isEditing) {
             const fetchSupplier = async () => {
                 try {
-                    const response = await axiosInstance.get(`/suppliers/${id}/`);
+                    const response = await axiosInstance.get(`suppliers/${id}/`);
                     setFormData(response.data);
                     if (response.data.image) {
                         setImagePreview(`${API_BASE_URL}${response.data.image}`);
@@ -69,8 +69,8 @@ function SupplierFormPage() {
         }
 
         const apiCall = isEditing
-            ? axiosInstance.patch(`/suppliers/${id}/`, submissionData)
-            : axiosInstance.post('/suppliers/', submissionData);
+            ? axiosInstance.patch(`suppliers/${id}/`, submissionData)
+            : axiosInstance.post('suppliers/', submissionData);
 
         try {
             await apiCall;

--- a/frontend/src/pages/SupplierListPage.js
+++ b/frontend/src/pages/SupplierListPage.js
@@ -24,7 +24,7 @@ function SupplierListPage() {
 
     const fetchSuppliers = async () => {
         try {
-            const response = await axiosInstance.get('/suppliers/', {
+            const response = await axiosInstance.get('suppliers/', {
                 params: { search: searchTerm }
             });
             setSuppliers(response.data);


### PR DESCRIPTION
## Summary
- ensure supplier API calls use paths relative to axios base URL
- adjust related components to fetch and submit supplier data reliably

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68bff12970f883239db77efe47a289df