### PR TITLE
fix: omit id when saving product

### DIFF
--- a/frontend/src/pages/ProductFormPage.js
+++ b/frontend/src/pages/ProductFormPage.js
@@ -20,7 +20,8 @@ function ProductFormPage() {
         if (isEditing) {
             axiosInstance.get(`/products/${id}/`)
                 .then(response => {
-                    setFormData(response.data);
+                    const { id: _removed, image, ...data } = response.data;
+                    setFormData(data);
                 })
                 .catch(error => setError('Failed to fetch product details.'));
         }
@@ -41,7 +42,7 @@ function ProductFormPage() {
         e.preventDefault();
         const submissionData = new FormData();
         Object.keys(formData).forEach(key => {
-            if (key !== 'image') {
+            if (key !== 'image' && key !== 'id') {
                 submissionData.append(key, formData[key]);
             }
         });


### PR DESCRIPTION
## Summary
- ignore read-only fields when submitting product form
- strip id and image from loaded product data

## Testing
- `npm test -- --watchAll=false` *(fails: Failed to fetch currency options)*

------
https://chatgpt.com/codex/tasks/task_e_68bff4c1ec3c832383adea1c9824d6ce