### PR TITLE
Allow cross currency payments

### DIFF
--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -121,26 +121,38 @@ class PaymentSerializer(serializers.ModelSerializer):
 
     def validate(self, attrs):
         account = attrs.get('account') or (self.instance.account if self.instance else None)
-        original_currency = attrs.get('original_currency') or (account.currency if account else None)
-        if account and original_currency and account.currency != original_currency:
-            raise serializers.ValidationError({'original_currency': 'Currency must match selected account currency.'})
+        original_currency = attrs.get('original_currency') or (
+            self.instance.original_currency if self.instance else None
+        )
 
-        customer = self.context.get('customer') or (self.instance.customer if self.instance else None)
-        if customer:
-            attrs['original_currency'] = original_currency or customer.currency
-            if attrs['original_currency'] != customer.currency:
-                exchange_rate = attrs.get('exchange_rate')
-                if not exchange_rate or Decimal(str(exchange_rate)) <= 0:
-                    try:
-                        attrs['exchange_rate'] = get_exchange_rate(
-                            attrs['original_currency'], customer.currency
-                        )
-                    except ValueError:
-                        raise serializers.ValidationError(
-                            {'exchange_rate': 'Exchange rate required when currencies differ.'}
-                        )
-            else:
-                attrs['exchange_rate'] = Decimal('1')
+        customer = self.context.get('customer') or (
+            self.instance.customer if self.instance else None
+        )
+        if customer and not original_currency:
+            original_currency = attrs['original_currency'] = customer.currency
+
+        target_currency = account.currency if account else (
+            customer.currency if customer else None
+        )
+
+        if (
+            original_currency
+            and target_currency
+            and original_currency != target_currency
+        ):
+            exchange_rate = attrs.get('exchange_rate')
+            if not exchange_rate or Decimal(str(exchange_rate)) <= 0:
+                try:
+                    attrs['exchange_rate'] = get_exchange_rate(
+                        original_currency, target_currency
+                    )
+                except ValueError:
+                    raise serializers.ValidationError(
+                        {'exchange_rate': 'Exchange rate required when currencies differ.'}
+                    )
+        else:
+            attrs['exchange_rate'] = Decimal('1')
+
         return attrs
 
 class ProductSerializer(serializers.ModelSerializer):

--- a/backend/api/tests/test_legacy.py
+++ b/backend/api/tests/test_legacy.py
@@ -317,34 +317,33 @@ class CrossCurrencyPaymentTest(TestCase):
         self.assertEqual(self.account.balance, Decimal('100.00'))
         self.assertEqual(self.customer.balance, Decimal('90.00'))
 
-    @patch('api.serializers.get_exchange_rate', return_value=Decimal('1.20'))
-    def test_exchange_rate_auto_fetched_when_currencies_differ(self, mock_rate):
+    @patch('api.serializers.get_exchange_rate', return_value=Decimal('0.90'))
+    def test_exchange_rate_auto_fetched_when_account_currency_differs(self, mock_rate):
         data = {
             'payment_date': date.today(),
             'original_amount': Decimal('50.00'),
-            'original_currency': 'EUR',
+            'original_currency': 'USD',
             'method': 'Cash',
             'account': self.account.id,
         }
         serializer = PaymentSerializer(data=data, context={'customer': self.customer})
         self.assertTrue(serializer.is_valid(), serializer.errors)
-        self.assertEqual(serializer.validated_data['exchange_rate'], Decimal('1.20'))
-        mock_rate.assert_called_once_with('EUR', 'USD')
+        self.assertEqual(serializer.validated_data['exchange_rate'], Decimal('0.90'))
+        mock_rate.assert_called_once_with('USD', 'EUR')
 
-    @patch('api.serializers.get_exchange_rate')
-    def test_currency_must_match_account(self, mock_rate):
+    @patch('api.serializers.get_exchange_rate', side_effect=ValueError)
+    def test_error_when_rate_unavailable_and_currencies_differ(self, mock_rate):
         data = {
             'payment_date': date.today(),
             'original_amount': Decimal('50.00'),
             'original_currency': 'USD',
-            'exchange_rate': Decimal('1'),
             'method': 'Cash',
             'account': self.account.id,
         }
         serializer = PaymentSerializer(data=data, context={'customer': self.customer})
         self.assertFalse(serializer.is_valid())
-        self.assertIn('original_currency', serializer.errors)
-        mock_rate.assert_not_called()
+        self.assertIn('exchange_rate', serializer.errors)
+        mock_rate.assert_called_once_with('USD', 'EUR')
 
 
 


### PR DESCRIPTION
## Summary
- allow original payment currency to differ from selected account
- require/fetch exchange rate when currencies differ
- cover cross currency scenarios in serializer tests

## Testing
- `python backend/manage.py test api.tests -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68bffb9089dc8323894623e0c7a3e8bd