### PR TITLE
Fix payment modal currency conversion logic

### DIFF
--- a/frontend/src/components/AddPaymentModal.js
+++ b/frontend/src/components/AddPaymentModal.js
@@ -71,23 +71,12 @@ function AddPaymentModal({ show, handleClose, saleId, onPaymentAdded }) {
 
     useEffect(() => {
         const amt = parseFloat(amount) || 0;
-        if (account && paymentCurrency !== accountCurrency) {
-
-    const selectedAccount = account ? accounts.find(a => a.id === parseInt(account)) : null;
-    const accountCurrency = selectedAccount ? selectedAccount.currency : customerCurrency;
-
-    useEffect(() => {
-        const amt = parseFloat(amount) || 0;
         if (paymentCurrency !== accountCurrency) {
-
             setConvertedAmount((amt * exchangeRate).toFixed(2));
         } else {
             setExchangeRate(1);
             setConvertedAmount(amount);
         }
-
-    }, [amount, paymentCurrency, accountCurrency, account, exchangeRate]);
-
     }, [amount, paymentCurrency, accountCurrency, exchangeRate]);
 
 
@@ -201,8 +190,6 @@ function AddPaymentModal({ show, handleClose, saleId, onPaymentAdded }) {
                             ))}
                         </Form.Select>
                     </Form.Group>
-
-                    {account && paymentCurrency !== accountCurrency && (
 
                     {paymentCurrency !== accountCurrency && (
 

--- a/frontend/src/components/CustomerPaymentModal.js
+++ b/frontend/src/components/CustomerPaymentModal.js
@@ -88,23 +88,12 @@ function CustomerPaymentModal({ show, handleClose, customerId, onPaymentAdded, p
 
     useEffect(() => {
         const amt = parseFloat(amount) || 0;
-        if (account && paymentCurrency !== accountCurrency) {
-
-    const selectedAccount = account ? accounts.find(a => a.id === parseInt(account)) : null;
-    const accountCurrency = selectedAccount ? selectedAccount.currency : customerCurrency;
-
-    useEffect(() => {
-        const amt = parseFloat(amount) || 0;
         if (paymentCurrency !== accountCurrency) {
-
             setConvertedAmount((amt * exchangeRate).toFixed(2));
         } else {
             setExchangeRate(1);
             setConvertedAmount(amount);
         }
-
-    }, [amount, paymentCurrency, accountCurrency, account, exchangeRate]);
-
     }, [amount, paymentCurrency, accountCurrency, exchangeRate]);
 
 
@@ -217,8 +206,6 @@ function CustomerPaymentModal({ show, handleClose, customerId, onPaymentAdded, p
                             ))}
                         </Form.Select>
                     </Form.Group>
-
-                    {account && paymentCurrency !== accountCurrency && (
 
                     {paymentCurrency !== accountCurrency && (
 

--- a/frontend/src/components/SupplierPaymentModal.js
+++ b/frontend/src/components/SupplierPaymentModal.js
@@ -83,23 +83,12 @@ function SupplierPaymentModal({ show, handleClose, supplierId, onPaymentAdded, p
 
     useEffect(() => {
         const amt = parseFloat(amount) || 0;
-        if (account && paymentCurrency !== accountCurrency) {
-
-    const selectedAccount = account ? accounts.find(a => a.id === parseInt(account)) : null;
-    const accountCurrency = selectedAccount ? selectedAccount.currency : baseCurrency;
-
-    useEffect(() => {
-        const amt = parseFloat(amount) || 0;
         if (paymentCurrency !== accountCurrency) {
-
             setConvertedAmount((amt * exchangeRate).toFixed(2));
         } else {
             setExchangeRate(1);
             setConvertedAmount(amount);
         }
-
-    }, [amount, paymentCurrency, accountCurrency, account, exchangeRate]);
-
     }, [amount, paymentCurrency, accountCurrency, exchangeRate]);
 
 
@@ -129,10 +118,9 @@ function SupplierPaymentModal({ show, handleClose, supplierId, onPaymentAdded, p
         if (account && paymentCurrency !== accountCurrency) {
             paymentData.account_exchange_rate = exchangeRate;
             paymentData.account_converted_amount = parseFloat(convertedAmount);
-
+        }
         if (paymentCurrency !== accountCurrency) {
             paymentData.exchange_rate = exchangeRate;
-
         }
 
         try {
@@ -203,8 +191,6 @@ function SupplierPaymentModal({ show, handleClose, supplierId, onPaymentAdded, p
                             ))}
                         </Form.Select>
                     </Form.Group>
-
-                    {account && paymentCurrency !== accountCurrency && (
 
                     {paymentCurrency !== accountCurrency && (
 


### PR DESCRIPTION
## Summary
- simplify currency conversion hooks in payment modals
- render exchange rate fields only when currencies differ
- ensure submit handlers include exchange rate values correctly

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68c3f7e669748323816f9b622c404607