### PR TITLE
Improve exchange rate retrieval robustness

### DIFF
--- a/backend/api/exchange_rates.py
+++ b/backend/api/exchange_rates.py
@@ -1,40 +1,59 @@
 from decimal import Decimal
 from typing import Optional
 
+import logging
 import requests
+from django.conf import settings
 from django.core.cache import cache
 
 
-def get_exchange_rate(from_currency: str, to_currency: str, manual_rate: Optional[float] = None) -> Decimal:
-    """Return exchange rate from `from_currency` to `to_currency`.
+logger = logging.getLogger(__name__)
+
+
+def get_exchange_rate(
+    from_currency: str, to_currency: str, manual_rate: Optional[float] = None
+) -> Decimal:
+    """Return exchange rate from ``from_currency`` to ``to_currency``.
 
     Results are cached to minimize external API calls. A manually provided rate
-    can be supplied via ``manual_rate`` to bypass the API and will also be
-    cached. Raises ``ValueError`` if a rate cannot be determined.
+    can be supplied via ``manual_rate`` to act as a fallback when the external
+    service is unavailable; when used it will be cached for subsequent lookups.
     """
     if from_currency == to_currency:
         return Decimal('1')
 
-    cache_key = f'exchange_rate_{from_currency}_{to_currency}'
+    cache_key = f"exchange_rate_{from_currency}_{to_currency}"
     cached_rate = cache.get(cache_key)
-    if cached_rate:
+    if cached_rate is not None:
         return Decimal(str(cached_rate))
 
+    manual_rate_decimal: Optional[Decimal] = None
     if manual_rate is not None:
-        rate = Decimal(str(manual_rate))
-        cache.set(cache_key, rate, timeout=3600)
-        return rate
+        manual_rate_decimal = Decimal(str(manual_rate))
+
+    api_url = getattr(settings, "EXCHANGE_RATE_API_URL", "https://api.exchangerate.host/latest")
 
     try:
         response = requests.get(
-            'https://api.exchangerate.host/latest',
-            params={'base': from_currency, 'symbols': to_currency},
+            api_url,
+            params={"base": from_currency, "symbols": to_currency},
             timeout=10,
         )
         response.raise_for_status()
         data = response.json()
-        rate = Decimal(str(data['rates'][to_currency]))
+        rate_value = data["rates"][to_currency]
+        rate = Decimal(str(rate_value))
         cache.set(cache_key, rate, timeout=3600)
         return rate
     except Exception as exc:
-        raise ValueError('Unable to fetch exchange rate') from exc
+        logger.exception(
+            "Failed to fetch exchange rate from %s for %s -> %s", api_url, from_currency, to_currency
+        )
+        if manual_rate_decimal is not None:
+            cache.set(cache_key, manual_rate_decimal, timeout=3600)
+            return manual_rate_decimal
+        if cached_rate is not None:
+            return Decimal(str(cached_rate))
+        raise RuntimeError(
+            f"Unable to fetch exchange rate for {from_currency} to {to_currency}"
+        ) from exc

--- a/backend/api/tests/test_exchange_rates.py
+++ b/backend/api/tests/test_exchange_rates.py
@@ -1,0 +1,52 @@
+from decimal import Decimal
+from unittest.mock import Mock, patch
+
+from django.core.cache import cache
+from django.test import SimpleTestCase, override_settings
+
+from ..exchange_rates import get_exchange_rate
+
+
+class GetExchangeRateTests(SimpleTestCase):
+    def setUp(self):
+        super().setUp()
+        cache.clear()
+
+    def tearDown(self):
+        cache.clear()
+        super().tearDown()
+
+    @override_settings(EXCHANGE_RATE_API_URL="https://example.com/rates")
+    @patch("api.exchange_rates.requests.get")
+    def test_fetches_rate_from_configured_url(self, mock_get: Mock) -> None:
+        response = Mock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = {"rates": {"EUR": 1.1}}
+        mock_get.return_value = response
+
+        rate = get_exchange_rate("USD", "EUR")
+
+        self.assertEqual(rate, Decimal("1.1"))
+        mock_get.assert_called_once_with(
+            "https://example.com/rates",
+            params={"base": "USD", "symbols": "EUR"},
+            timeout=10,
+        )
+
+    @patch("api.exchange_rates.requests.get", side_effect=Exception("boom"))
+    def test_returns_manual_rate_when_request_fails(self, mock_get: Mock) -> None:
+        with self.assertLogs("api.exchange_rates", level="ERROR") as captured:
+            rate = get_exchange_rate("USD", "EUR", manual_rate=1.23)
+
+        self.assertEqual(rate, Decimal("1.23"))
+        self.assertTrue(any("Failed to fetch exchange rate" in msg for msg in captured.output))
+        self.assertEqual(cache.get("exchange_rate_USD_EUR"), Decimal("1.23"))
+        mock_get.assert_called_once()
+
+    @patch("api.exchange_rates.requests.get", side_effect=Exception("boom"))
+    def test_raises_runtime_error_when_no_fallback_available(self, mock_get: Mock) -> None:
+        with self.assertLogs("api.exchange_rates", level="ERROR"):
+            with self.assertRaises(RuntimeError):
+                get_exchange_rate("USD", "EUR")
+
+        mock_get.assert_called_once()

--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -151,5 +151,11 @@ REST_FRAMEWORK = {
 }
 
 
+EXCHANGE_RATE_API_URL = os.environ.get(
+    "EXCHANGE_RATE_API_URL",
+    "https://api.exchangerate.host/latest",
+)
+
+
 MEDIA_URL = '/media/'
 MEDIA_ROOT = BASE_DIR / 'media'


### PR DESCRIPTION
## Summary
- add an `EXCHANGE_RATE_API_URL` setting with a sensible default
- update `get_exchange_rate` to read the configured endpoint, add logging, and return manual fallback rates when available
- add unit tests covering the configured URL, fallback behavior, and error handling

## Testing
- python manage.py test api.tests.test_exchange_rates

------
https://chatgpt.com/codex/tasks/task_e_68c9228e39b88323bb9a847107e01ac8