### PR TITLE
Switch backend to PostgreSQL

### DIFF
--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -90,8 +90,12 @@ WSGI_APPLICATION = "core.wsgi.application"
 
 DATABASES = {
     "default": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": BASE_DIR / "db.sqlite3",
+        "ENGINE": "django.db.backends.postgresql",
+        "NAME": os.environ.get("POSTGRES_DB", "accounting_app"),
+        "USER": os.environ.get("POSTGRES_USER", "accounting_user"),
+        "PASSWORD": os.environ.get("POSTGRES_PASSWORD", "accounting_pass"),
+        "HOST": os.environ.get("POSTGRES_HOST", "localhost"),
+        "PORT": os.environ.get("POSTGRES_PORT", "5432"),
     }
 }
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,3 +6,4 @@ drf-nested-routers
 Pillow
 reportlab
 requests
+psycopg2-binary


### PR DESCRIPTION
## Summary
- configure the Django database settings to use PostgreSQL credentials that can be supplied via environment variables
- add the psycopg2-binary dependency so the app can connect to PostgreSQL

## Testing
- python3 backend/manage.py check
- python3 backend/manage.py migrate
- python3 backend/manage.py loaddata backend/db_dump.json

------
https://chatgpt.com/codex/tasks/task_e_68c92c2919088323ac6a332fb194812e