### PR TITLE
Add reusable action menu and apply to entity lists

### DIFF
--- a/frontend/src/components/ActionMenu.css
+++ b/frontend/src/components/ActionMenu.css
@@ -1,0 +1,35 @@
+.action-menu {
+    position: relative;
+}
+
+.action-menu-toggle {
+    padding: 0.25rem;
+    line-height: 1;
+    background-color: transparent !important;
+    border: none !important;
+    box-shadow: none !important;
+    color: inherit;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.action-menu-toggle:hover,
+.action-menu-toggle:focus {
+    background-color: rgba(0, 0, 0, 0.05) !important;
+}
+
+.action-menu-toggle:focus-visible {
+    box-shadow: 0 0 0 0.25rem rgba(13, 110, 253, 0.35) !important;
+}
+
+.action-menu-dropdown {
+    min-width: 12rem;
+    font-size: 0.9rem;
+}
+
+.action-menu-item-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}

--- a/frontend/src/components/ActionMenu.js
+++ b/frontend/src/components/ActionMenu.js
@@ -1,0 +1,94 @@
+import React, { useId } from 'react';
+import PropTypes from 'prop-types';
+import { Dropdown } from 'react-bootstrap';
+import { BsThreeDotsVertical } from 'react-icons/bs';
+import './ActionMenu.css';
+
+const buildClassName = (classes) => classes.filter(Boolean).join(' ');
+
+function ActionMenu({ actions, align, className, menuClassName, toggleAriaLabel, stopPropagation, id, ...rest }) {
+    const generatedId = useId();
+    const dropdownId = id || `action-menu-${generatedId}`;
+    const dropdownClassName = buildClassName(['action-menu', className]);
+    const menuClasses = buildClassName(['action-menu-dropdown', menuClassName]);
+    const handleClickCapture = stopPropagation ? (event) => event.stopPropagation() : undefined;
+
+    return (
+        <Dropdown
+            align={align}
+            className={dropdownClassName}
+            onClickCapture={handleClickCapture}
+            {...rest}
+        >
+            <Dropdown.Toggle
+                id={dropdownId}
+                variant="light"
+                size="sm"
+                className="action-menu-toggle"
+                aria-label={toggleAriaLabel}
+            >
+                <span className="visually-hidden">{toggleAriaLabel}</span>
+                <BsThreeDotsVertical aria-hidden="true" />
+            </Dropdown.Toggle>
+            <Dropdown.Menu className={menuClasses}>
+                {actions.map((action, index) => {
+                    const itemKey = action.key ?? index;
+                    const itemClasses = buildClassName([
+                        'd-flex align-items-center gap-2',
+                        action.variant,
+                    ]);
+                    const itemProps = action.href ? { href: action.href } : {};
+
+                    return (
+                        <Dropdown.Item
+                            key={itemKey}
+                            className={itemClasses}
+                            disabled={action.disabled}
+                            {...itemProps}
+                            onClick={(event) => {
+                                if (typeof action.onClick === 'function') {
+                                    action.onClick(event);
+                                }
+                            }}
+                        >
+                            {action.icon && <span className="action-menu-item-icon">{action.icon}</span>}
+                            <span>{action.label}</span>
+                        </Dropdown.Item>
+                    );
+                })}
+            </Dropdown.Menu>
+        </Dropdown>
+    );
+}
+
+ActionMenu.propTypes = {
+    actions: PropTypes.arrayOf(PropTypes.shape({
+        label: PropTypes.string.isRequired,
+        icon: PropTypes.node,
+        variant: PropTypes.string,
+        onClick: PropTypes.func,
+        disabled: PropTypes.bool,
+        href: PropTypes.string,
+        key: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    })).isRequired,
+    align: PropTypes.oneOfType([
+        PropTypes.oneOf(['start', 'end']),
+        PropTypes.object,
+    ]),
+    className: PropTypes.string,
+    menuClassName: PropTypes.string,
+    toggleAriaLabel: PropTypes.string,
+    stopPropagation: PropTypes.bool,
+    id: PropTypes.string,
+};
+
+ActionMenu.defaultProps = {
+    align: 'end',
+    className: '',
+    menuClassName: '',
+    toggleAriaLabel: 'Open actions menu',
+    stopPropagation: false,
+    id: undefined,
+};
+
+export default ActionMenu;

--- a/frontend/src/pages/BankAccountListPage.js
+++ b/frontend/src/pages/BankAccountListPage.js
@@ -3,8 +3,10 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Alert, Badge, Button, Card, Col, Form, Modal, Row, Spinner } from 'react-bootstrap';
+import { FaEdit, FaTrash } from 'react-icons/fa';
 import axiosInstance from '../utils/axiosInstance';
 import { ACCOUNT_CATEGORY_MAP, ACCOUNT_CATEGORY_OPTIONS, getCategoryConfig } from '../utils/bankAccountCategories';
+import ActionMenu from '../components/ActionMenu';
 
 const AVAILABLE_CURRENCIES = ['USD', 'EUR', 'KZT', 'TRY'];
 
@@ -219,27 +221,24 @@ function BankAccountListPage() {
                                                                 {account.category_label || ACCOUNT_CATEGORY_MAP[account.category]?.label}
                                                             </Badge>
                                                         </div>
-                                                        <div className="d-flex justify-content-end gap-2 mt-3">
-                                                            <Button
-                                                                variant="outline-secondary"
-                                                                size="sm"
-                                                                onClick={(event) => {
-                                                                    event.stopPropagation();
-                                                                    handleShowModal(account);
-                                                                }}
-                                                            >
-                                                                Edit
-                                                            </Button>
-                                                            <Button
-                                                                variant="outline-danger"
-                                                                size="sm"
-                                                                onClick={(event) => {
-                                                                    event.stopPropagation();
-                                                                    handleDelete(account.id);
-                                                                }}
-                                                            >
-                                                                Delete
-                                                            </Button>
+                                                        <div className="d-flex justify-content-end mt-3">
+                                                            <ActionMenu
+                                                                stopPropagation
+                                                                toggleAriaLabel={`Account actions for ${account.name}`}
+                                                                actions={[
+                                                                    {
+                                                                        label: 'Edit Account',
+                                                                        icon: <FaEdit />,
+                                                                        onClick: () => handleShowModal(account),
+                                                                    },
+                                                                    {
+                                                                        label: 'Delete Account',
+                                                                        icon: <FaTrash />,
+                                                                        variant: 'text-danger',
+                                                                        onClick: () => handleDelete(account.id),
+                                                                    },
+                                                                ]}
+                                                            />
                                                         </div>
                                                     </Card.Body>
                                                 </Card>

--- a/frontend/src/pages/CustomerDetailPage.js
+++ b/frontend/src/pages/CustomerDetailPage.js
@@ -4,9 +4,10 @@ import React, { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import axiosInstance from '../utils/axiosInstance';
 import { Container, Card, Row, Col, Spinner, Alert, Button, Accordion, ButtonToolbar, Table, Modal } from 'react-bootstrap';
-import { PersonCircle, Cash, Tag, Hammer, BarChart } from 'react-bootstrap-icons';
+import { PersonCircle, Cash, Tag, Hammer, BarChart, PencilSquare, Trash } from 'react-bootstrap-icons';
 import './CustomerDetailPage.css';
 import CustomerPaymentModal from '../components/CustomerPaymentModal';
+import ActionMenu from '../components/ActionMenu';
 
 const API_BASE_URL = 'http://127.0.0.1:8000';
 
@@ -198,42 +199,59 @@ function CustomerDetailPage() {
                         <Card.Header as="h5">Previous Sales</Card.Header>
                         <Card.Body>
                             <Accordion>
-                                {sales.map((sale, index) => (
-                                    <Accordion.Item eventKey={index.toString()} key={sale.id}>
-                                        <Accordion.Header style={{ backgroundColor: '#f8f9fa' }}>
-                                            <div className="d-flex justify-content-between w-100 pe-3">
-                                                <span>{new Date(sale.sale_date).toLocaleDateString()}</span>
-                                                <strong>{formatCurrency(sale.total_amount, customer.currency)}</strong>
-                                            </div>
-                                        </Accordion.Header>
-                                        <Accordion.Body>
-                                            <div className="d-flex justify-content-end mb-2">
-                                                <Button size="sm" variant="warning" onClick={() => navigate(`/sales/${sale.id}/edit`)}>Edit</Button>
-                                                <Button size="sm" variant="danger" className="ms-2" onClick={() => handleDeleteSale(sale.id)}>Delete</Button>
-                                            </div>
-                                            <Table striped bordered hover size="sm">
-                                                <thead>
-                                                    <tr>
-                                                        <th>Product</th>
-                                                        <th>Quantity</th>
-                                                        <th>Unit Price</th>
-                                                        <th className="text-end">Line Total</th>
-                                                    </tr>
-                                                </thead>
-                                                <tbody>
-                                                    {sale.items.map(item => (
-                                                        <tr key={item.id}>
-                                                            <td>{item.product_name}</td>
-                                                            <td>{item.quantity}</td>
-                                                            <td>{formatCurrency(item.unit_price, customer.currency)}</td>
-                                                            <td className="text-end">{formatCurrency(item.line_total, customer.currency)}</td>
+                                {sales.map((sale, index) => {
+                                    const saleDate = new Date(sale.sale_date).toLocaleDateString();
+                                    return (
+                                        <Accordion.Item eventKey={index.toString()} key={sale.id}>
+                                            <Accordion.Header style={{ backgroundColor: '#f8f9fa' }}>
+                                                <div className="d-flex justify-content-between w-100 pe-3">
+                                                    <span>{saleDate}</span>
+                                                    <strong>{formatCurrency(sale.total_amount, customer.currency)}</strong>
+                                                </div>
+                                            </Accordion.Header>
+                                            <Accordion.Body>
+                                                <div className="d-flex justify-content-end mb-2">
+                                                    <ActionMenu
+                                                        toggleAriaLabel={`Sale actions for ${saleDate}`}
+                                                        actions={[
+                                                            {
+                                                                label: 'Edit Sale',
+                                                                icon: <PencilSquare />,
+                                                                onClick: () => navigate(`/sales/${sale.id}/edit`),
+                                                            },
+                                                            {
+                                                                label: 'Delete Sale',
+                                                                icon: <Trash />,
+                                                                variant: 'text-danger',
+                                                                onClick: () => handleDeleteSale(sale.id),
+                                                            },
+                                                        ]}
+                                                    />
+                                                </div>
+                                                <Table striped bordered hover size="sm">
+                                                    <thead>
+                                                        <tr>
+                                                            <th>Product</th>
+                                                            <th>Quantity</th>
+                                                            <th>Unit Price</th>
+                                                            <th className="text-end">Line Total</th>
                                                         </tr>
-                                                    ))}
-                                                </tbody>
-                                            </Table>
-                                        </Accordion.Body>
-                                    </Accordion.Item>
-                                ))}
+                                                    </thead>
+                                                    <tbody>
+                                                        {sale.items.map(item => (
+                                                            <tr key={item.id}>
+                                                                <td>{item.product_name}</td>
+                                                                <td>{item.quantity}</td>
+                                                                <td>{formatCurrency(item.unit_price, customer.currency)}</td>
+                                                                <td className="text-end">{formatCurrency(item.line_total, customer.currency)}</td>
+                                                            </tr>
+                                                        ))}
+                                                    </tbody>
+                                                </Table>
+                                            </Accordion.Body>
+                                        </Accordion.Item>
+                                    );
+                                })}
                             </Accordion>
                         </Card.Body>
                     </Card>
@@ -243,35 +261,52 @@ function CustomerDetailPage() {
                        <Card.Header as="h5">Previous Payments</Card.Header>
                        <Card.Body>
                             <Accordion>
-                                {payments.map((payment, index) => (
-                                    <Accordion.Item eventKey={index.toString()} key={payment.id}>
-                                        <Accordion.Header style={{ backgroundColor: '#d4edda' }}>
-                                            <div className="d-flex justify-content-between w-100 pe-3">
-                                                <span>{new Date(payment.payment_date).toLocaleDateString()}</span>
-                                                <span>{payment.method}</span>
-                                                <strong>{formatCurrency(payment.amount, customer.currency)}</strong>
-                                            </div>
-                                        </Accordion.Header>
-                                        <Accordion.Body>
-                                            <div className="d-flex justify-content-end mb-2">
-                                                <Button size="sm" variant="warning" onClick={() => handleEditPayment(payment)}>Edit</Button>
-                                                <Button size="sm" variant="danger" className="ms-2" onClick={() => handleDeletePayment(payment.id)}>Delete</Button>
-                                            </div>
-                                            <Table borderless size="sm" className="mb-0">
-                                                <tbody>
-                                                    <tr>
-                                                        <td className="fw-bold">Account</td>
-                                                        <td>{payment.account_name || 'N/A'}</td>
-                                                    </tr>
-                                                    <tr>
-                                                        <td className="fw-bold">Notes</td>
-                                                        <td>{payment.notes || 'No notes provided.'}</td>
-                                                    </tr>
-                                                </tbody>
-                                            </Table>
-                                        </Accordion.Body>
-                                    </Accordion.Item>
-                                ))}
+                                {payments.map((payment, index) => {
+                                    const paymentDate = new Date(payment.payment_date).toLocaleDateString();
+                                    return (
+                                        <Accordion.Item eventKey={index.toString()} key={payment.id}>
+                                            <Accordion.Header style={{ backgroundColor: '#d4edda' }}>
+                                                <div className="d-flex justify-content-between w-100 pe-3">
+                                                    <span>{paymentDate}</span>
+                                                    <span>{payment.method}</span>
+                                                    <strong>{formatCurrency(payment.amount, customer.currency)}</strong>
+                                                </div>
+                                            </Accordion.Header>
+                                            <Accordion.Body>
+                                                <div className="d-flex justify-content-end mb-2">
+                                                    <ActionMenu
+                                                        toggleAriaLabel={`Payment actions for ${paymentDate}`}
+                                                        actions={[
+                                                            {
+                                                                label: 'Edit Payment',
+                                                                icon: <PencilSquare />,
+                                                                onClick: () => handleEditPayment(payment),
+                                                            },
+                                                            {
+                                                                label: 'Delete Payment',
+                                                                icon: <Trash />,
+                                                                variant: 'text-danger',
+                                                                onClick: () => handleDeletePayment(payment.id),
+                                                            },
+                                                        ]}
+                                                    />
+                                                </div>
+                                                <Table borderless size="sm" className="mb-0">
+                                                    <tbody>
+                                                        <tr>
+                                                            <td className="fw-bold">Account</td>
+                                                            <td>{payment.account_name || 'N/A'}</td>
+                                                        </tr>
+                                                        <tr>
+                                                            <td className="fw-bold">Notes</td>
+                                                            <td>{payment.notes || 'No notes provided.'}</td>
+                                                        </tr>
+                                                    </tbody>
+                                                </Table>
+                                            </Accordion.Body>
+                                        </Accordion.Item>
+                                    );
+                                })}
                             </Accordion>
                        </Card.Body>
                     </Card>

--- a/frontend/src/pages/ExpenseListPage.js
+++ b/frontend/src/pages/ExpenseListPage.js
@@ -3,7 +3,8 @@
 import React, { useState, useEffect } from 'react';
 import axiosInstance from '../utils/axiosInstance';
 import { Table, Button, Card, Modal, Form, Alert, Row, Col, ListGroup, InputGroup } from 'react-bootstrap';
-import { FaTrash } from 'react-icons/fa';
+import { FaTrash, FaEdit } from 'react-icons/fa';
+import ActionMenu from '../components/ActionMenu';
 
 // This is the new, self-contained component for managing categories
 const CategoryManagerModal = ({ show, handleClose, categories, onUpdate }) => {
@@ -217,9 +218,22 @@ function ExpenseListPage() {
                                     <td>{expense.account_name || 'N/A'}</td>
                                     <td>{expense.description}</td>
                                     <td>${parseFloat(expense.amount).toFixed(2)}</td>
-                                    <td>
-                                        <Button variant="warning" size="sm" className="me-2" onClick={() => handleShowModal(expense)}>Edit</Button>
-                                        <Button variant="danger" size="sm" onClick={() => handleDelete(expense.id)}>Delete</Button>
+                                    <td className="text-nowrap">
+                                        <ActionMenu
+                                            actions={[
+                                                {
+                                                    label: 'Edit Expense',
+                                                    icon: <FaEdit />,
+                                                    onClick: () => handleShowModal(expense),
+                                                },
+                                                {
+                                                    label: 'Delete Expense',
+                                                    icon: <FaTrash />,
+                                                    variant: 'text-danger',
+                                                    onClick: () => handleDelete(expense.id),
+                                                },
+                                            ]}
+                                        />
                                     </td>
                                 </tr>
                             ))}

--- a/frontend/src/pages/SupplierDetailPage.js
+++ b/frontend/src/pages/SupplierDetailPage.js
@@ -4,9 +4,10 @@ import React, { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import axiosInstance from '../utils/axiosInstance';
 import { Container, Card, Row, Col, Spinner, Alert, Button, Accordion, ButtonToolbar, Table } from 'react-bootstrap';
-import { PersonCircle, Cash, Tag, Hammer, BarChart } from 'react-bootstrap-icons';
+import { PersonCircle, Cash, Tag, Hammer, BarChart, PencilSquare, Trash } from 'react-bootstrap-icons';
 import './SupplierDetailPage.css';
 import SupplierPaymentModal from '../components/SupplierPaymentModal';
+import ActionMenu from '../components/ActionMenu';
 
 const API_BASE_URL = 'http://127.0.0.1:8000';
 
@@ -195,42 +196,59 @@ function SupplierDetailPage() {
                         <Card.Header as="h5">Previous Purchases</Card.Header>
                         <Card.Body>
                             <Accordion>
-                                {purchases.map((purchase, index) => (
-                                    <Accordion.Item eventKey={index.toString()} key={purchase.id}>
-                                        <Accordion.Header style={{ backgroundColor: '#f8f9fa' }}>
-                                            <div className="d-flex justify-content-between w-100 pe-3">
-                                                <span>{new Date(purchase.purchase_date).toLocaleDateString()}</span>
-                                                <strong>{formatCurrency(purchase.total_amount, purchase.original_currency)}</strong>
-                                            </div>
-                                        </Accordion.Header>
-                                        <Accordion.Body>
-                                            <div className="d-flex justify-content-end mb-2">
-                                                <Button size="sm" variant="warning" onClick={() => navigate(`/purchases/${purchase.id}/edit`)}>Edit</Button>
-                                                <Button size="sm" variant="danger" className="ms-2" onClick={() => handleDeletePurchase(purchase.id)}>Delete</Button>
-                                            </div>
-                                            <Table striped bordered hover size="sm">
-                                                <thead>
-                                                    <tr>
-                                                        <th>Product</th>
-                                                        <th>Quantity</th>
-                                                        <th>Unit Price</th>
-                                                        <th className="text-end">Line Total</th>
-                                                    </tr>
-                                                </thead>
-                                                <tbody>
-                                                    {purchase.items.map(item => (
-                                                        <tr key={item.id}>
-                                                            <td>{item.product_name}</td>
-                                                            <td>{item.quantity}</td>
-                                                            <td>{formatCurrency(item.unit_price, purchase.original_currency)}</td>
-                                                            <td className="text-end">{formatCurrency(item.line_total, purchase.original_currency)}</td>
+                                {purchases.map((purchase, index) => {
+                                    const purchaseDate = new Date(purchase.purchase_date).toLocaleDateString();
+                                    return (
+                                        <Accordion.Item eventKey={index.toString()} key={purchase.id}>
+                                            <Accordion.Header style={{ backgroundColor: '#f8f9fa' }}>
+                                                <div className="d-flex justify-content-between w-100 pe-3">
+                                                    <span>{purchaseDate}</span>
+                                                    <strong>{formatCurrency(purchase.total_amount, purchase.original_currency)}</strong>
+                                                </div>
+                                            </Accordion.Header>
+                                            <Accordion.Body>
+                                                <div className="d-flex justify-content-end mb-2">
+                                                    <ActionMenu
+                                                        toggleAriaLabel={`Purchase actions for ${purchaseDate}`}
+                                                        actions={[
+                                                            {
+                                                                label: 'Edit Purchase',
+                                                                icon: <PencilSquare />,
+                                                                onClick: () => navigate(`/purchases/${purchase.id}/edit`),
+                                                            },
+                                                            {
+                                                                label: 'Delete Purchase',
+                                                                icon: <Trash />,
+                                                                variant: 'text-danger',
+                                                                onClick: () => handleDeletePurchase(purchase.id),
+                                                            },
+                                                        ]}
+                                                    />
+                                                </div>
+                                                <Table striped bordered hover size="sm">
+                                                    <thead>
+                                                        <tr>
+                                                            <th>Product</th>
+                                                            <th>Quantity</th>
+                                                            <th>Unit Price</th>
+                                                            <th className="text-end">Line Total</th>
                                                         </tr>
-                                                    ))}
-                                                </tbody>
-                                            </Table>
-                                        </Accordion.Body>
-                                    </Accordion.Item>
-                                ))}
+                                                    </thead>
+                                                    <tbody>
+                                                        {purchase.items.map(item => (
+                                                            <tr key={item.id}>
+                                                                <td>{item.product_name}</td>
+                                                                <td>{item.quantity}</td>
+                                                                <td>{formatCurrency(item.unit_price, purchase.original_currency)}</td>
+                                                                <td className="text-end">{formatCurrency(item.line_total, purchase.original_currency)}</td>
+                                                            </tr>
+                                                        ))}
+                                                    </tbody>
+                                                </Table>
+                                            </Accordion.Body>
+                                        </Accordion.Item>
+                                    );
+                                })}
                             </Accordion>
                         </Card.Body>
                     </Card>
@@ -239,42 +257,59 @@ function SupplierDetailPage() {
                         <Card.Header as="h5">Previous Sales</Card.Header>
                         <Card.Body>
                             <Accordion>
-                                {sales.map((sale, index) => (
-                                    <Accordion.Item eventKey={index.toString()} key={sale.id}>
-                                        <Accordion.Header style={{ backgroundColor: '#f8f9fa' }}>
-                                            <div className="d-flex justify-content-between w-100 pe-3">
-                                                <span>{new Date(sale.sale_date).toLocaleDateString()}</span>
-                                                <strong>{formatCurrency(sale.total_amount, sale.original_currency)}</strong>
-                                            </div>
-                                        </Accordion.Header>
-                                        <Accordion.Body>
-                                            <div className="d-flex justify-content-end mb-2">
-                                                <Button size="sm" variant="warning" onClick={() => navigate(`/sales/${sale.id}/edit`)}>Edit</Button>
-                                                <Button size="sm" variant="danger" className="ms-2" onClick={() => handleDeleteSale(sale.id)}>Delete</Button>
-                                            </div>
-                                            <Table striped bordered hover size="sm">
-                                                <thead>
-                                                    <tr>
-                                                        <th>Product</th>
-                                                        <th>Quantity</th>
-                                                        <th>Unit Price</th>
-                                                        <th className="text-end">Line Total</th>
-                                                    </tr>
-                                                </thead>
-                                                <tbody>
-                                                    {sale.items.map(item => (
-                                                        <tr key={item.id}>
-                                                            <td>{item.product_name}</td>
-                                                            <td>{item.quantity}</td>
-                                                            <td>{formatCurrency(item.unit_price, sale.original_currency)}</td>
-                                                            <td className="text-end">{formatCurrency(item.line_total, sale.original_currency)}</td>
+                                {sales.map((sale, index) => {
+                                    const saleDate = new Date(sale.sale_date).toLocaleDateString();
+                                    return (
+                                        <Accordion.Item eventKey={index.toString()} key={sale.id}>
+                                            <Accordion.Header style={{ backgroundColor: '#f8f9fa' }}>
+                                                <div className="d-flex justify-content-between w-100 pe-3">
+                                                    <span>{saleDate}</span>
+                                                    <strong>{formatCurrency(sale.total_amount, sale.original_currency)}</strong>
+                                                </div>
+                                            </Accordion.Header>
+                                            <Accordion.Body>
+                                                <div className="d-flex justify-content-end mb-2">
+                                                    <ActionMenu
+                                                        toggleAriaLabel={`Sale actions for ${saleDate}`}
+                                                        actions={[
+                                                            {
+                                                                label: 'Edit Sale',
+                                                                icon: <PencilSquare />,
+                                                                onClick: () => navigate(`/sales/${sale.id}/edit`),
+                                                            },
+                                                            {
+                                                                label: 'Delete Sale',
+                                                                icon: <Trash />,
+                                                                variant: 'text-danger',
+                                                                onClick: () => handleDeleteSale(sale.id),
+                                                            },
+                                                        ]}
+                                                    />
+                                                </div>
+                                                <Table striped bordered hover size="sm">
+                                                    <thead>
+                                                        <tr>
+                                                            <th>Product</th>
+                                                            <th>Quantity</th>
+                                                            <th>Unit Price</th>
+                                                            <th className="text-end">Line Total</th>
                                                         </tr>
-                                                    ))}
-                                                </tbody>
-                                            </Table>
-                                        </Accordion.Body>
-                                    </Accordion.Item>
-                                ))}
+                                                    </thead>
+                                                    <tbody>
+                                                        {sale.items.map(item => (
+                                                            <tr key={item.id}>
+                                                                <td>{item.product_name}</td>
+                                                                <td>{item.quantity}</td>
+                                                                <td>{formatCurrency(item.unit_price, sale.original_currency)}</td>
+                                                                <td className="text-end">{formatCurrency(item.line_total, sale.original_currency)}</td>
+                                                            </tr>
+                                                        ))}
+                                                    </tbody>
+                                                </Table>
+                                            </Accordion.Body>
+                                        </Accordion.Item>
+                                    );
+                                })}
                             </Accordion>
                         </Card.Body>
                     </Card>
@@ -284,35 +319,52 @@ function SupplierDetailPage() {
                         <Card.Header as="h5">Previous Payments</Card.Header>
                         <Card.Body>
                             <Accordion>
-                                {expenses.map((payment, index) => (
-                                    <Accordion.Item eventKey={index.toString()} key={payment.id}>
-                                        <Accordion.Header style={{ backgroundColor: '#d4edda' }}>
-                                            <div className="d-flex justify-content-between w-100 pe-3">
-                                                <span>{new Date(payment.expense_date).toLocaleDateString()}</span>
-                                                <span>{payment.method}</span>
-                                                <strong>{formatCurrency(payment.amount, payment.currency)}</strong>
-                                            </div>
-                                        </Accordion.Header>
-                                        <Accordion.Body>
-                                            <div className="d-flex justify-content-end mb-2">
-                                                <Button size="sm" variant="warning" onClick={() => handleEditPayment(payment)}>Edit</Button>
-                                                <Button size="sm" variant="danger" className="ms-2" onClick={() => handleDeletePayment(payment.id)}>Delete</Button>
-                                            </div>
-                                            <Table borderless size="sm" className="mb-0">
-                                                <tbody>
-                                                    <tr>
-                                                        <td className="fw-bold">Account</td>
-                                                        <td>{payment.account_name || 'N/A'}</td>
-                                                    </tr>
-                                                    <tr>
-                                                        <td className="fw-bold">Notes</td>
-                                                        <td>{payment.description || 'No notes provided.'}</td>
-                                                    </tr>
-                                                </tbody>
-                                            </Table>
-                                        </Accordion.Body>
-                                    </Accordion.Item>
-                                ))}
+                                {expenses.map((payment, index) => {
+                                    const paymentDate = new Date(payment.expense_date).toLocaleDateString();
+                                    return (
+                                        <Accordion.Item eventKey={index.toString()} key={payment.id}>
+                                            <Accordion.Header style={{ backgroundColor: '#d4edda' }}>
+                                                <div className="d-flex justify-content-between w-100 pe-3">
+                                                    <span>{paymentDate}</span>
+                                                    <span>{payment.method}</span>
+                                                    <strong>{formatCurrency(payment.amount, payment.currency)}</strong>
+                                                </div>
+                                            </Accordion.Header>
+                                            <Accordion.Body>
+                                                <div className="d-flex justify-content-end mb-2">
+                                                    <ActionMenu
+                                                        toggleAriaLabel={`Payment actions for ${paymentDate}`}
+                                                        actions={[
+                                                            {
+                                                                label: 'Edit Payment',
+                                                                icon: <PencilSquare />,
+                                                                onClick: () => handleEditPayment(payment),
+                                                            },
+                                                            {
+                                                                label: 'Delete Payment',
+                                                                icon: <Trash />,
+                                                                variant: 'text-danger',
+                                                                onClick: () => handleDeletePayment(payment.id),
+                                                            },
+                                                        ]}
+                                                    />
+                                                </div>
+                                                <Table borderless size="sm" className="mb-0">
+                                                    <tbody>
+                                                        <tr>
+                                                            <td className="fw-bold">Account</td>
+                                                            <td>{payment.account_name || 'N/A'}</td>
+                                                        </tr>
+                                                        <tr>
+                                                            <td className="fw-bold">Notes</td>
+                                                            <td>{payment.description || 'No notes provided.'}</td>
+                                                        </tr>
+                                                    </tbody>
+                                                </Table>
+                                            </Accordion.Body>
+                                        </Accordion.Item>
+                                    );
+                                })}
                             </Accordion>
                         </Card.Body>
                     </Card>


### PR DESCRIPTION
## Summary
- create a reusable ActionMenu dropdown component styled to blend with existing layouts
- switch expense, bank account, supplier, and customer detail pages to use the new menu for per-item actions

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68ca7e64a7108323ba8189913637debd