### PR TITLE
Fix bank account action menu propagation

### DIFF
--- a/frontend/src/components/ActionMenu.js
+++ b/frontend/src/components/ActionMenu.js
@@ -34,6 +34,9 @@ function ActionMenu({ actions, align, className, menuClassName, toggleAriaLabel,
 
     const handleToggle = (event) => {
         event.preventDefault();
+        if (stopPropagation) {
+            event.stopPropagation();
+        }
         setShow((previous) => !previous);
     };
 
@@ -92,6 +95,9 @@ function ActionMenu({ actions, align, className, menuClassName, toggleAriaLabel,
                                     className={itemClasses}
                                     {...itemProps}
                                     onClick={(event) => {
+                                        if (stopPropagation) {
+                                            event.stopPropagation();
+                                        }
                                         if (action.disabled) {
                                             event.preventDefault();
                                             return;


### PR DESCRIPTION
## Summary
- prevent action menu events from bubbling to parent cards when stopPropagation is enabled
- ensure edit and delete actions on bank account cards operate without triggering navigation

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68ca8e174ff08323a74ad11d0c73f9db