### PR TITLE
Add global card shadows

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -11,3 +11,26 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
 }
+
+/* Provide a consistent elevated appearance for all cards */
+.card {
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.card:not(.shadow-none) {
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+}
+
+.card:not(.shadow-none):hover {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.12);
+}
+
+.card.shadow-sm {
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08) !important;
+}
+
+.card.shadow-sm:hover {
+  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.12) !important;
+}


### PR DESCRIPTION
## Summary
- add consistent elevation styling for Bootstrap cards so they are easier to distinguish from the background
- ensure hover states deepen the shadow while respecting existing `.shadow-sm` and `.shadow-none` utility classes

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68ca9cf18be483239115969ffdf11912