### PR TITLE
Improve readability of displayed amounts

### DIFF
--- a/frontend/src/components/BankAccountsOverview.js
+++ b/frontend/src/components/BankAccountsOverview.js
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { Card, Row, Col, Spinner, Alert, ListGroup } from 'react-bootstrap';
 import { FaLandmark } from 'react-icons/fa';
 import axiosInstance from '../utils/axiosInstance';
+import { formatNumber } from '../utils/format';
 
 function BankAccountsOverview() {
   const [accounts, setAccounts] = useState([]);
@@ -47,7 +48,7 @@ function BankAccountsOverview() {
             {Object.entries(totals).map(([currency, amount]) => (
               <ListGroup.Item key={currency} className="d-flex justify-content-between align-items-center">
                 <span className="fw-bold">{currency}</span>
-                <span className="badge bg-primary rounded-pill fs-6">{amount.toFixed(2)}</span>
+                <span className="badge bg-primary rounded-pill fs-6">{formatNumber(amount)}</span>
               </ListGroup.Item>
             ))}
           </ListGroup>
@@ -61,7 +62,7 @@ function BankAccountsOverview() {
                 <FaLandmark size={30} className="me-3 text-muted" />
                 <div>
                   <h6 className="mb-1">{account.name}</h6>
-                  <h4 className="mb-0">{parseFloat(account.balance).toFixed(2)} <small className="text-muted">{account.currency}</small></h4>
+                  <h4 className="mb-0">{formatNumber(account.balance)} <small className="text-muted">{account.currency}</small></h4>
                 </div>
               </Card.Body>
             </Card>

--- a/frontend/src/pages/EditSalePage.js
+++ b/frontend/src/pages/EditSalePage.js
@@ -5,6 +5,7 @@ import axiosInstance from '../utils/axiosInstance';
 import { useNavigate, useParams } from 'react-router-dom';
 import { Form, Button, Card, Row, Col, Table, Alert, Spinner } from 'react-bootstrap';
 import { FaTrash } from 'react-icons/fa';
+import { formatCurrency } from '../utils/format';
 
 function EditSalePage() {
     const { id } = useParams();
@@ -66,8 +67,10 @@ function EditSalePage() {
     };
     const calculateTotal = () => {
         return saleItems.reduce((total, item) => {
-            return total + (Number(item.quantity) * Number(item.unit_price));
-        }, 0).toFixed(2);
+            const quantity = Number(item.quantity) || 0;
+            const price = Number(item.unit_price) || 0;
+            return total + quantity * price;
+        }, 0);
     };
     // -----------------------------------------
 
@@ -140,7 +143,7 @@ function EditSalePage() {
                                     <td>
                                         <Form.Control type="number" name="unit_price" value={item.unit_price} onChange={e => handleItemChange(index, e)} step="0.01" required />
                                     </td>
-                                    <td>${(Number(item.quantity) * Number(item.unit_price)).toFixed(2)}</td>
+                                    <td>{formatCurrency((Number(item.quantity) || 0) * (Number(item.unit_price) || 0))}</td>
                                     <td>
                                         <Button variant="danger" onClick={() => handleRemoveItem(index)}><FaTrash /></Button>
                                     </td>
@@ -150,7 +153,7 @@ function EditSalePage() {
                     </Table>
                     <Button variant="secondary" onClick={handleAddItem} className="mb-3">+ Add Item</Button>
                     <div className="text-end">
-                        <h3>Total: ${calculateTotal()}</h3>
+                        <h3>Total: {formatCurrency(calculateTotal())}</h3>
                     </div>
                     <div className="mt-3">
                         <Button variant="primary" type="submit">Update Sale</Button>

--- a/frontend/src/pages/ExpenseListPage.js
+++ b/frontend/src/pages/ExpenseListPage.js
@@ -5,6 +5,7 @@ import axiosInstance from '../utils/axiosInstance';
 import { Table, Button, Card, Modal, Form, Alert, Row, Col, ListGroup, InputGroup } from 'react-bootstrap';
 import { FaTrash, FaEdit } from 'react-icons/fa';
 import ActionMenu from '../components/ActionMenu';
+import { formatCurrency } from '../utils/format';
 
 // This is the new, self-contained component for managing categories
 const CategoryManagerModal = ({ show, handleClose, categories, onUpdate }) => {
@@ -217,7 +218,7 @@ function ExpenseListPage() {
                                     <td>{expense.category_name || 'Uncategorized'}</td>
                                     <td>{expense.account_name || 'N/A'}</td>
                                     <td>{expense.description}</td>
-                                    <td>${parseFloat(expense.amount).toFixed(2)}</td>
+                                    <td>{formatCurrency(expense.amount)}</td>
                                     <td className="text-nowrap">
                                         <ActionMenu
                                             actions={[

--- a/frontend/src/pages/OfferDetailPage.js
+++ b/frontend/src/pages/OfferDetailPage.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import axiosInstance from '../utils/axiosInstance';
 import { Card, Button, Spinner, Alert, Row, Col, Table } from 'react-bootstrap';
+import { formatCurrency } from '../utils/format';
 
 function OfferDetailPage() {
     const { id } = useParams();
@@ -85,8 +86,8 @@ function OfferDetailPage() {
                                         <td>{index + 1}</td>
                                         <td>{item.product_name}</td>
                                         <td>{item.quantity}</td>
-                                        <td>${parseFloat(item.unit_price).toFixed(2)}</td>
-                                        <td>${(item.quantity * item.unit_price).toFixed(2)}</td>
+                                        <td>{formatCurrency(item.unit_price)}</td>
+                                        <td>{formatCurrency(item.quantity * item.unit_price)}</td>
                                     </tr>
                                 ))}
                             </tbody>
@@ -98,7 +99,7 @@ function OfferDetailPage() {
                             <Col md={12} className="text-end">
                                 <h4 className="mb-0">
                                     <strong>Total:</strong>
-                                    <span className="float-end">${parseFloat(offer.total_amount).toFixed(2)}</span>
+                                    <span className="float-end">{formatCurrency(offer.total_amount)}</span>
                                 </h4>
                             </Col>
                         </Row>

--- a/frontend/src/pages/OfferListPage.js
+++ b/frontend/src/pages/OfferListPage.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import axiosInstance from '../utils/axiosInstance';
 import { Card, Button, Table, Alert, Spinner } from 'react-bootstrap';
+import { formatCurrency } from '../utils/format';
 
 function OfferListPage() {
     const [offers, setOffers] = useState([]);
@@ -61,7 +62,7 @@ function OfferListPage() {
                                     <td>{offer.customer_name}</td>
                                     <td>{new Date(offer.offer_date).toLocaleDateString()}</td>
                                     <td>{offer.status}</td>
-                                    <td>${parseFloat(offer.total_amount).toFixed(2)}</td>
+                                    <td>{formatCurrency(offer.total_amount)}</td>
                                     <td>
                                         <Button as={Link} to={`/offers/${offer.id}`} variant="info" size="sm">
                                         View

--- a/frontend/src/pages/ProfitLossPage.js
+++ b/frontend/src/pages/ProfitLossPage.js
@@ -3,6 +3,7 @@
 import React, { useState } from 'react';
 import axiosInstance from '../utils/axiosInstance';
 import { Card, Button, Form, Row, Col, Spinner, Alert, Table } from 'react-bootstrap';
+import { formatCurrency } from '../utils/format';
 
 // Helper to get the first day of the current month
 const getFirstDayOfMonth = () => {
@@ -47,16 +48,6 @@ function ProfitLossPage() {
             setLoading(false);
         }
     };
-
-    const formatCurrency = (amount) => {
-        const value = parseFloat(amount);
-        const formatted = value.toFixed(2);
-        if (value < 0) {
-            return `-$${Math.abs(value).toFixed(2)}`;
-        }
-        return `$${formatted}`;
-    };
-
     return (
         <Card>
             <Card.Header>

--- a/frontend/src/pages/PurchaseDetailPage.js
+++ b/frontend/src/pages/PurchaseDetailPage.js
@@ -4,6 +4,7 @@ import React, { useState, useEffect } from 'react';
 import { useParams, useNavigate, Link } from 'react-router-dom';
 import axiosInstance from '../utils/axiosInstance';
 import { Card, Button, Spinner, Alert, Row, Col, Table } from 'react-bootstrap';
+import { formatCurrency } from '../utils/format';
 
 function PurchaseDetailPage() {
     const { id } = useParams();
@@ -63,13 +64,13 @@ function PurchaseDetailPage() {
                                     <tr key={item.id}>
                                         <td>{item.product_name}</td>
                                         <td>{item.quantity}</td>
-                                        <td>${parseFloat(item.unit_price).toFixed(2)}</td>
-                                        <td>${parseFloat(item.line_total).toFixed(2)}</td>
+                                        <td>{formatCurrency(item.unit_price, purchase.original_currency || 'USD')}</td>
+                                        <td>{formatCurrency(item.line_total, purchase.original_currency || 'USD')}</td>
                                     </tr>
                                 ))}
                             </tbody>
                         </Table>
-                        <h4 className="text-end mt-3">Total: ${parseFloat(purchase.total_amount).toFixed(2)}</h4>
+                        <h4 className="text-end mt-3">Total: {formatCurrency(purchase.total_amount, purchase.original_currency || 'USD')}</h4>
                     </Card.Body>
                     <Card.Footer className="text-end">
                         <Button as={Link} to={`/purchases/${purchase.id}/edit`} variant="warning" className="me-2">Edit</Button>

--- a/frontend/src/pages/PurchaseListPage.js
+++ b/frontend/src/pages/PurchaseListPage.js
@@ -4,6 +4,7 @@ import React, { useState, useEffect } from 'react';
 import axiosInstance from '../utils/axiosInstance';
 import { Link } from 'react-router-dom';
 import { Form, Button, Card, Row, Col, Table, Alert, Modal, Spinner } from 'react-bootstrap';
+import { formatCurrency } from '../utils/format';
 import { FaTrash } from 'react-icons/fa';
 
 const getTodayDate = () => {
@@ -171,7 +172,7 @@ function PurchaseListPage() {
                                     <td>{purchase.supplier_name}</td>
                                     <td>{purchase.bill_number || 'N/A'}</td>
                                     <td>{purchase.account_name || 'N/A'}</td>
-                                    <td>${parseFloat(purchase.total_amount).toFixed(2)}</td>
+                                    <td>{formatCurrency(purchase.total_amount, purchase.original_currency || 'USD')}</td>
                                     <td>
                                         <Button as={Link} to={`/purchases/${purchase.id}`} variant="info" size="sm">View</Button>
                                     </td>

--- a/frontend/src/pages/SaleListPage.js
+++ b/frontend/src/pages/SaleListPage.js
@@ -4,6 +4,7 @@ import React, { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import axiosInstance from '../utils/axiosInstance';
 import { Card, Button, Table, Alert, Spinner } from 'react-bootstrap';
+import { formatCurrency } from '../utils/format';
 
 function SaleListPage() {
     const [sales, setSales] = useState([]);
@@ -63,7 +64,7 @@ function SaleListPage() {
                                     {/* 'customer_name' comes from our SaleReadSerializer */}
                                     <td>{sale.customer_name}</td>
                                     <td>{new Date(sale.sale_date).toLocaleDateString()}</td>
-                                    <td>${parseFloat(sale.total_amount).toFixed(2)}</td>
+                                    <td>{formatCurrency(sale.total_amount, sale.original_currency || 'USD')}</td>
                                     <td>
                                         <Button as={Link} to={`/sales/${sale.id}`} variant="info" size="sm">
                                         View

--- a/frontend/src/pages/SalesReportPage.js
+++ b/frontend/src/pages/SalesReportPage.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import axiosInstance from '../utils/axiosInstance';
 import { Card, Button, Form, Row, Col, Spinner, Alert, Table, Collapse } from 'react-bootstrap';
+import { formatCurrency } from '../utils/format';
 
 // Helper to get the first day of the current month
 const getFirstDayOfMonth = () => {
@@ -45,11 +46,6 @@ function SalesReportPage() {
             setLoading(false);
         }
     };
-
-    const formatCurrency = (amount) => {
-        return `$${parseFloat(amount).toFixed(2)}`;
-    };
-
     const toggleRow = (id) => {
         setOpenRows(prev => ({ ...prev, [id]: !prev[id] }));
     };

--- a/frontend/src/pages/TransactionPage.js
+++ b/frontend/src/pages/TransactionPage.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import axiosInstance from '../utils/axiosInstance';
 import { useNavigate } from 'react-router-dom';
 import { Form, Button, Card, Row, Col, Table, Alert } from 'react-bootstrap';
+import { formatCurrency } from '../utils/format';
 import { FaTrash } from 'react-icons/fa';
 
 function TransactionPage() {
@@ -66,8 +67,10 @@ function TransactionPage() {
     // Calculate the total amount of the sale
     const calculateTotal = () => {
         return saleItems.reduce((total, item) => {
-            return total + (Number(item.quantity) * Number(item.unit_price));
-        }, 0).toFixed(2);
+            const quantity = Number(item.quantity) || 0;
+            const price = Number(item.unit_price) || 0;
+            return total + quantity * price;
+        }, 0);
     };
 
     // Handle form submission
@@ -176,7 +179,7 @@ function TransactionPage() {
                                         />
                                     </td>
                                     <td>
-                                        ${(Number(item.quantity) * Number(item.unit_price)).toFixed(2)}
+                                        {formatCurrency((Number(item.quantity) || 0) * (Number(item.unit_price) || 0))}
                                     </td>
                                     <td>
                                         <Button variant="danger" onClick={() => handleRemoveItem(index)}>
@@ -193,7 +196,7 @@ function TransactionPage() {
                     </Button>
 
                     <div className="text-end">
-                        <h3>Total: ${calculateTotal()}</h3>
+                        <h3>Total: {formatCurrency(calculateTotal())}</h3>
                     </div>
 
                     <div className="mt-3">

--- a/frontend/src/utils/format.js
+++ b/frontend/src/utils/format.js
@@ -1,0 +1,72 @@
+const DEFAULT_LOCALE = 'en-US';
+const DEFAULT_MIN_FRACTION_DIGITS = 2;
+const DEFAULT_MAX_FRACTION_DIGITS = 2;
+
+const toNumericValue = (value) => {
+    if (typeof value === 'number') {
+        return Number.isFinite(value) ? value : 0;
+    }
+
+    if (typeof value === 'string') {
+        // Remove common formatting characters such as commas before parsing
+        const normalised = value.replace(/,/g, '').trim();
+        const parsed = Number(normalised);
+        return Number.isFinite(parsed) ? parsed : 0;
+    }
+
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+};
+
+export const formatNumber = (
+    value,
+    {
+        locale = DEFAULT_LOCALE,
+        minimumFractionDigits = DEFAULT_MIN_FRACTION_DIGITS,
+        maximumFractionDigits = DEFAULT_MAX_FRACTION_DIGITS,
+    } = {},
+) => {
+    const numericValue = toNumericValue(value);
+
+    try {
+        return new Intl.NumberFormat(locale, {
+            minimumFractionDigits,
+            maximumFractionDigits,
+        }).format(numericValue);
+    } catch (error) {
+        // Fallback to a simple fixed decimal representation if Intl fails
+        const fractionDigits = Math.min(
+            Math.max(minimumFractionDigits ?? DEFAULT_MIN_FRACTION_DIGITS, 0),
+            Math.max(maximumFractionDigits ?? DEFAULT_MAX_FRACTION_DIGITS, 20),
+        );
+        return numericValue.toFixed(fractionDigits);
+    }
+};
+
+export const formatCurrency = (
+    value,
+    currency = 'USD',
+    {
+        locale = DEFAULT_LOCALE,
+        minimumFractionDigits = DEFAULT_MIN_FRACTION_DIGITS,
+        maximumFractionDigits = DEFAULT_MAX_FRACTION_DIGITS,
+    } = {},
+) => {
+    const numericValue = toNumericValue(value);
+
+    try {
+        return new Intl.NumberFormat(locale, {
+            style: 'currency',
+            currency,
+            minimumFractionDigits,
+            maximumFractionDigits,
+        }).format(numericValue);
+    } catch (error) {
+        const formattedNumber = formatNumber(numericValue, {
+            locale,
+            minimumFractionDigits,
+            maximumFractionDigits,
+        });
+        return currency ? `${currency} ${formattedNumber}` : formattedNumber;
+    }
+};


### PR DESCRIPTION
## Summary
- add a shared formatting utility that produces localized currency and decimal strings with thousands separators
- update bank, offer, purchase, sale, transaction, expense and reporting views to rely on the formatter instead of manual toFixed calls

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68caa6ef9a4c832393ed6fca96efa714