### PR TITLE
Fix expense amounts showing USD for non-USD accounts

### DIFF
--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -423,6 +423,9 @@ class ExpenseSerializer(serializers.ModelSerializer):
     # This makes the category name appear in the API response, which is more useful than just the ID.
     category_name = serializers.CharField(source='category.name', read_only=True, allow_null=True)
     account_name = serializers.CharField(source='account.name', read_only=True)
+    account_currency = serializers.CharField(
+        source='account.currency', read_only=True, allow_null=True
+    )
     supplier_name = serializers.CharField(source='supplier.name', read_only=True, allow_null=True)
 
     class Meta:
@@ -436,6 +439,7 @@ class ExpenseSerializer(serializers.ModelSerializer):
             'description',
             'account',
             'account_name',
+            'account_currency',
             'supplier',
             'supplier_name',
         ]

--- a/frontend/src/pages/ExpenseListPage.js
+++ b/frontend/src/pages/ExpenseListPage.js
@@ -6,6 +6,7 @@ import { Table, Button, Card, Modal, Form, Alert, Row, Col, ListGroup, InputGrou
 import { FaTrash, FaEdit } from 'react-icons/fa';
 import ActionMenu from '../components/ActionMenu';
 import { formatCurrency } from '../utils/format';
+import { getBaseCurrency, loadBaseCurrency } from '../config/currency';
 
 // This is the new, self-contained component for managing categories
 const CategoryManagerModal = ({ show, handleClose, categories, onUpdate }) => {
@@ -91,6 +92,7 @@ function ExpenseListPage() {
     const [isEditing, setIsEditing] = useState(false);
     const [currentExpense, setCurrentExpense] = useState(null);
     const [showCategoryModal, setShowCategoryModal] = useState(false); // State for the new modal
+    const [baseCurrency, setBaseCurrency] = useState(getBaseCurrency());
     const [formData, setFormData] = useState({
         amount: '',
         expense_date: getTodayDate(),
@@ -118,6 +120,10 @@ function ExpenseListPage() {
 
     useEffect(() => {
         fetchData();
+    }, []);
+
+    useEffect(() => {
+        loadBaseCurrency().then(setBaseCurrency);
     }, []);
 
     const handleInputChange = (e) => {
@@ -218,7 +224,7 @@ function ExpenseListPage() {
                                     <td>{expense.category_name || 'Uncategorized'}</td>
                                     <td>{expense.account_name || 'N/A'}</td>
                                     <td>{expense.description}</td>
-                                    <td>{formatCurrency(expense.amount)}</td>
+                                    <td>{formatCurrency(expense.amount, expense.account_currency || baseCurrency)}</td>
                                     <td className="text-nowrap">
                                         <ActionMenu
                                             actions={[


### PR DESCRIPTION
## Summary
- expose each expense's account currency from the API so the client knows how it was funded
- fall back to the company base currency when no account is linked and render list amounts with the correct currency symbol

## Testing
- .venv/bin/python manage.py test *(fails: connection refused to PostgreSQL server)*

------
https://chatgpt.com/codex/tasks/task_e_68cae56a9df483238ea83e1e0ce146ed