### PR TITLE
Add currency breakdowns to dashboard summary

### DIFF
--- a/backend/api/tests/test_dashboard_summary.py
+++ b/backend/api/tests/test_dashboard_summary.py
@@ -1,0 +1,165 @@
+"""Tests for the dashboard summary endpoint."""
+
+from decimal import Decimal
+
+from django.contrib.auth.models import User
+from django.test import TestCase
+from django.utils import timezone
+from rest_framework.test import APIClient
+
+from ..models import (
+    BankAccount,
+    Customer,
+    Expense,
+    Payment,
+    Product,
+    Purchase,
+    Sale,
+    Supplier,
+)
+
+
+class DashboardSummaryTest(TestCase):
+    """Validate currency-aware aggregates in the dashboard summary response."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(username='dash', password='pw')
+        self.client = APIClient()
+        self.client.force_authenticate(self.user)
+
+        self.customer_usd = Customer.objects.create(
+            name='Acme',
+            currency='USD',
+            created_by=self.user,
+        )
+        self.customer_eur = Customer.objects.create(
+            name='Euro Corp',
+            currency='EUR',
+            created_by=self.user,
+        )
+        self.supplier = Supplier.objects.create(
+            name='SupplyCo',
+            currency='USD',
+            created_by=self.user,
+        )
+        self.account = BankAccount.objects.create(
+            name='Operating',
+            currency='USD',
+            created_by=self.user,
+        )
+
+        Product.objects.create(
+            name='Widget',
+            sale_price=Decimal('10.00'),
+            purchase_price=Decimal('5.00'),
+            stock_quantity=Decimal('10'),
+            created_by=self.user,
+        )
+
+    def test_dashboard_summary_includes_currency_breakdowns(self):
+        today = timezone.now().date()
+
+        Sale.objects.create(
+            customer=self.customer_usd,
+            original_currency='USD',
+            original_amount=Decimal('100.00'),
+            exchange_rate=Decimal('1'),
+            created_by=self.user,
+        )
+        Sale.objects.create(
+            customer=self.customer_eur,
+            original_currency='EUR',
+            original_amount=Decimal('200.00'),
+            exchange_rate=Decimal('1'),
+            created_by=self.user,
+        )
+
+        Payment.objects.create(
+            customer=self.customer_usd,
+            payment_date=today,
+            original_amount=Decimal('40.00'),
+            original_currency='USD',
+            exchange_rate=Decimal('1'),
+            created_by=self.user,
+        )
+
+        Purchase.objects.create(
+            supplier=self.supplier,
+            purchase_date=today,
+            original_currency='USD',
+            original_amount=Decimal('150.00'),
+            exchange_rate=Decimal('1'),
+            created_by=self.user,
+        )
+
+        Expense.objects.create(
+            amount=Decimal('30.00'),
+            expense_date=today,
+            account=self.account,
+            created_by=self.user,
+        )
+        Expense.objects.create(
+            amount=Decimal('50.00'),
+            expense_date=today,
+            supplier=self.supplier,
+            created_by=self.user,
+        )
+
+        response = self.client.get('/api/dashboard-summary/')
+        self.assertEqual(response.status_code, 200, response.content)
+
+        data = response.data
+
+        self.assertEqual(Decimal(str(data['turnover'])), Decimal('300'))
+        self.assertEqual(Decimal(str(data['total_receivables'])), Decimal('260'))
+        self.assertEqual(Decimal(str(data['total_payables'])), Decimal('100'))
+        self.assertEqual(Decimal(str(data['expenses'])), Decimal('80'))
+        self.assertEqual(Decimal(str(data['stock_value'])), Decimal('50'))
+
+        self.assertEqual(
+            Decimal(str(data['turnover_breakdown']['USD'])),
+            Decimal('100'),
+        )
+        self.assertEqual(
+            Decimal(str(data['turnover_breakdown']['EUR'])),
+            Decimal('200'),
+        )
+
+        self.assertEqual(
+            Decimal(str(data['total_receivables_breakdown']['USD'])),
+            Decimal('60'),
+        )
+        self.assertEqual(
+            Decimal(str(data['total_receivables_breakdown']['EUR'])),
+            Decimal('200'),
+        )
+
+        self.assertEqual(
+            Decimal(str(data['total_payables_breakdown']['USD'])),
+            Decimal('100'),
+        )
+
+        self.assertEqual(
+            Decimal(str(data['expenses_breakdown']['USD'])),
+            Decimal('80'),
+        )
+
+        stock_breakdown = data['stock_value_breakdown']
+        self.assertIn('USD', stock_breakdown)
+        self.assertEqual(Decimal(str(stock_breakdown['USD'])), Decimal('50'))
+
+        today_sales_breakdown = data['today_sales_breakdown']
+        self.assertEqual(
+            Decimal(str(today_sales_breakdown['USD'])),
+            Decimal('100'),
+        )
+        self.assertEqual(
+            Decimal(str(today_sales_breakdown['EUR'])),
+            Decimal('200'),
+        )
+
+        incoming_breakdown = data['today_incoming_breakdown']
+        self.assertEqual(
+            Decimal(str(incoming_breakdown['USD'])),
+            Decimal('40'),
+        )

--- a/backend/api/views/common.py
+++ b/backend/api/views/common.py
@@ -1,13 +1,16 @@
 """Common utility views for general API endpoints."""
 
-from django.db.models import DecimalField, F, Q, Sum
+from decimal import Decimal
+
+from django.db.models import (Case, CharField, DecimalField, F, Sum, Value,
+                              When)
 from django.db.models.functions import Coalesce
 from django.utils import timezone
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
-from ..models import Customer, Payment, Sale
+from ..models import CompanySettings, Customer, Expense, Payment, Purchase, Sale
 
 
 @api_view(['GET'])
@@ -23,54 +26,135 @@ def dashboard_summary(request):
     """Provide summary data for the dashboard."""
     user = request.user
 
-    sales_total = Sale.objects.filter(
-        Q(customer__created_by=user) | Q(supplier__created_by=user)
-    ).aggregate(total=Coalesce(Sum('total_amount'), 0, output_field=DecimalField()))['total']
-    payments_total = Payment.objects.filter(customer__created_by=user).aggregate(
-        total=Coalesce(Sum('converted_amount'), 0, output_field=DecimalField())
+    base_currency = CompanySettings.load().base_currency
+
+    zero = Decimal('0')
+
+    def _currency_breakdown(queryset, currency_field, amount_field):
+        aggregates = queryset.values(currency_field).annotate(
+            total=Coalesce(Sum(amount_field), zero, output_field=DecimalField())
+        )
+        breakdown = {}
+        for entry in aggregates:
+            currency = entry[currency_field]
+            total = entry['total']
+            if currency and total:
+                breakdown[currency] = total
+        return breakdown
+
+    sales_qs = Sale.objects.filter(created_by=user)
+    sales_total = sales_qs.aggregate(
+        total=Coalesce(Sum('converted_amount'), zero, output_field=DecimalField())
     )['total']
-    total_receivables = sales_total - payments_total
+    turnover_breakdown = _currency_breakdown(sales_qs, 'original_currency', 'original_amount')
+
+    customer_sales_qs = sales_qs.filter(customer__created_by=user)
+    customer_sales_total = customer_sales_qs.aggregate(
+        total=Coalesce(Sum('converted_amount'), zero, output_field=DecimalField())
+    )['total']
+    customer_sales_breakdown = _currency_breakdown(
+        customer_sales_qs, 'original_currency', 'original_amount'
+    )
+
+    payments_qs = Payment.objects.filter(created_by=user, customer__created_by=user)
+    payments_total = payments_qs.aggregate(
+        total=Coalesce(Sum('converted_amount'), zero, output_field=DecimalField())
+    )['total']
+    customer_payment_breakdown = _currency_breakdown(
+        payments_qs.annotate(currency=F('customer__currency')),
+        'currency',
+        'converted_amount',
+    )
+    total_receivables = customer_sales_total - payments_total
+    receivables_breakdown = {}
+    for currency in set(customer_sales_breakdown) | set(customer_payment_breakdown):
+        balance = customer_sales_breakdown.get(currency, zero) - customer_payment_breakdown.get(currency, zero)
+        if balance:
+            receivables_breakdown[currency] = balance
 
     today = timezone.now().date()
-    today_sales = Sale.objects.filter(
-        Q(customer__created_by=user) | Q(supplier__created_by=user), sale_date=today
-    ).aggregate(total=Coalesce(Sum('total_amount'), 0, output_field=DecimalField()))['total']
-    today_payments_qs = Payment.objects.filter(
-        customer__created_by=user, payment_date=today
-    )
-    today_incoming = today_payments_qs.aggregate(
-        total=Coalesce(Sum('converted_amount'), 0, output_field=DecimalField())
+    today_sales_qs = sales_qs.filter(sale_date=today)
+    today_sales = today_sales_qs.aggregate(
+        total=Coalesce(Sum('converted_amount'), zero, output_field=DecimalField())
     )['total']
-
-    today_incoming_currency_totals = today_payments_qs.values('original_currency').annotate(
-        total=Coalesce(Sum('original_amount'), 0, output_field=DecimalField())
+    today_sales_breakdown = _currency_breakdown(
+        today_sales_qs, 'original_currency', 'original_amount'
     )
-    today_incoming_breakdown = {
-        entry['original_currency']: entry['total']
-        for entry in today_incoming_currency_totals
-        if entry['total']
-    }
+
+    today_payments_qs = payments_qs.filter(payment_date=today)
+    today_incoming = today_payments_qs.aggregate(
+        total=Coalesce(Sum('converted_amount'), zero, output_field=DecimalField())
+    )['total']
+    today_incoming_breakdown = _currency_breakdown(
+        today_payments_qs, 'original_currency', 'original_amount'
+    )
+
+    expenses_qs = Expense.objects.filter(created_by=user)
+    total_expenses = expenses_qs.aggregate(
+        total=Coalesce(Sum('amount'), zero, output_field=DecimalField())
+    )['total']
+    expenses_currency_qs = expenses_qs.annotate(
+        currency=Case(
+            When(account__currency__isnull=False, then=F('account__currency')),
+            When(supplier__currency__isnull=False, then=F('supplier__currency')),
+            default=Value(base_currency),
+            output_field=CharField(),
+        )
+    )
+    expenses_breakdown = _currency_breakdown(expenses_currency_qs, 'currency', 'amount')
+
+    purchases_qs = Purchase.objects.filter(created_by=user, supplier__created_by=user)
+    credit_purchases_qs = purchases_qs.filter(account__isnull=True)
+    credit_purchase_total = credit_purchases_qs.aggregate(
+        total=Coalesce(Sum('converted_amount'), zero, output_field=DecimalField())
+    )['total']
+    credit_purchase_breakdown = _currency_breakdown(
+        credit_purchases_qs, 'original_currency', 'original_amount'
+    )
+
+    supplier_expenses_qs = expenses_qs.filter(supplier__created_by=user)
+    supplier_expenses_total = supplier_expenses_qs.aggregate(
+        total=Coalesce(Sum('amount'), zero, output_field=DecimalField())
+    )['total']
+    supplier_expenses_currency_qs = supplier_expenses_qs.annotate(
+        currency=Case(
+            When(supplier__currency__isnull=False, then=F('supplier__currency')),
+            When(account__currency__isnull=False, then=F('account__currency')),
+            default=Value(base_currency),
+            output_field=CharField(),
+        )
+    )
+    supplier_expenses_breakdown = _currency_breakdown(
+        supplier_expenses_currency_qs, 'currency', 'amount'
+    )
+
+    payables_breakdown = {}
+    for currency in set(credit_purchase_breakdown) | set(supplier_expenses_breakdown):
+        balance = credit_purchase_breakdown.get(currency, zero) - supplier_expenses_breakdown.get(currency, zero)
+        if balance:
+            payables_breakdown[currency] = balance
+    total_payables = credit_purchase_total - supplier_expenses_total
 
     stock_value = user.products.aggregate(
-        total_value=Coalesce(Sum(F('purchase_price') * F('stock_quantity')), 0, output_field=DecimalField())
+        total_value=Coalesce(Sum(F('purchase_price') * F('stock_quantity')), zero, output_field=DecimalField())
     )['total_value']
-
-    total_expenses = user.expenses.aggregate(
-        total=Coalesce(Sum('amount'), 0, output_field=DecimalField())
-    )['total']
-
-    total_payables = user.suppliers.aggregate(
-        total=Coalesce(Sum('open_balance'), 0, output_field=DecimalField())
-    )['total']
+    stock_value = stock_value or zero
+    stock_value_breakdown = {base_currency: stock_value} if stock_value else {}
 
     data = {
         'total_receivables': total_receivables,
+        'total_receivables_breakdown': receivables_breakdown,
         'total_payables': total_payables,
+        'total_payables_breakdown': payables_breakdown,
         'turnover': sales_total,
+        'turnover_breakdown': turnover_breakdown,
         'expenses': total_expenses,
+        'expenses_breakdown': expenses_breakdown,
         'stock_value': stock_value,
+        'stock_value_breakdown': stock_value_breakdown,
         'customer_count': user.customers.count(),
         'today_sales': today_sales,
+        'today_sales_breakdown': today_sales_breakdown,
         'today_incoming': today_incoming,
         'today_incoming_breakdown': today_incoming_breakdown,
     }

--- a/frontend/src/pages/DashboardPage.js
+++ b/frontend/src/pages/DashboardPage.js
@@ -34,9 +34,7 @@ const ProgressCard = ({ title, items, headerColor = 'primary', currency = 'USD' 
                 {items.map(({ label, value, variant, breakdown }, idx) => {
                     const percentage = total > 0 ? (Number(value) / total) * 100 : 0;
                     const breakdownEntries = breakdown && Object.entries(breakdown);
-                    const displayValue = breakdownEntries && breakdownEntries.length > 0
-                        ? breakdownEntries.map(([code, amount]) => formatCurrency(amount, code)).join(', ')
-                        : formatCurrency(value, currency);
+                    const displayValue = formatCurrency(value, currency);
                     return (
                         <div key={idx} className="mb-3">
                             <div className="d-flex justify-content-between">
@@ -103,19 +101,54 @@ function DashboardPage() {
     }
 
     const assetItems = summary ? [
-        { label: 'Receivables', value: summary.total_receivables, variant: 'success' },
-        { label: 'Stock Value', value: summary.stock_value, variant: 'info' },
-        { label: "Today's Incoming", value: summary.today_incoming, variant: 'warning', breakdown: summary.today_incoming_breakdown || {} }
+        {
+            label: 'Receivables',
+            value: summary.total_receivables,
+            variant: 'success',
+            breakdown: summary.total_receivables_breakdown || {},
+        },
+        {
+            label: 'Stock Value',
+            value: summary.stock_value,
+            variant: 'info',
+            breakdown: summary.stock_value_breakdown || {},
+        },
+        {
+            label: "Today's Incoming",
+            value: summary.today_incoming,
+            variant: 'warning',
+            breakdown: summary.today_incoming_breakdown || {},
+        }
     ] : [];
 
     const liabilityItems = summary ? [
-        { label: 'Payables', value: summary.total_payables, variant: 'danger' },
-        { label: 'Expenses', value: summary.expenses, variant: 'secondary' }
+        {
+            label: 'Payables',
+            value: summary.total_payables,
+            variant: 'danger',
+            breakdown: summary.total_payables_breakdown || {},
+        },
+        {
+            label: 'Expenses',
+            value: summary.expenses,
+            variant: 'secondary',
+            breakdown: summary.expenses_breakdown || {},
+        }
     ] : [];
 
     const performanceItems = summary ? [
-        { label: 'Turnover', value: summary.turnover, variant: 'primary' },
-        { label: "Today's Sales", value: summary.today_sales, variant: 'success' }
+        {
+            label: 'Turnover',
+            value: summary.turnover,
+            variant: 'primary',
+            breakdown: summary.turnover_breakdown || {},
+        },
+        {
+            label: "Today's Sales",
+            value: summary.today_sales,
+            variant: 'success',
+            breakdown: summary.today_sales_breakdown || {},
+        }
     ] : [];
 
     return (

--- a/frontend/src/pages/DashboardPage.test.js
+++ b/frontend/src/pages/DashboardPage.test.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import DashboardPage from './DashboardPage';
+import axiosInstance from '../utils/axiosInstance';
+
+jest.mock('../utils/axiosInstance', () => ({
+  get: jest.fn(),
+}));
+
+jest.mock('../config/currency', () => ({
+  getBaseCurrency: jest.fn(() => 'USD'),
+  loadBaseCurrency: jest.fn(() => Promise.resolve('USD')),
+}));
+
+jest.mock('../components/BankAccountsOverview', () => () => <div data-testid="bank-accounts-overview" />);
+jest.mock('../components/RecentActivities', () => () => <div data-testid="recent-activities" />);
+
+describe('DashboardPage currency breakdowns', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('renders per-currency breakdown values for dashboard metrics', async () => {
+    const summary = {
+      total_receivables: '260.00',
+      total_receivables_breakdown: { USD: '60.00', EUR: '200.00' },
+      total_payables: '100.00',
+      total_payables_breakdown: { USD: '100.00' },
+      turnover: '300.00',
+      turnover_breakdown: { USD: '100.00', EUR: '200.00' },
+      expenses: '80.00',
+      expenses_breakdown: { USD: '80.00' },
+      stock_value: '50.00',
+      stock_value_breakdown: { USD: '50.00' },
+      customer_count: 2,
+      today_sales: '300.00',
+      today_sales_breakdown: { USD: '100.00', EUR: '200.00' },
+      today_incoming: '40.00',
+      today_incoming_breakdown: { USD: '40.00' },
+    };
+
+    axiosInstance.get.mockResolvedValueOnce({ data: summary });
+
+    render(<DashboardPage />);
+
+    await waitFor(() => expect(axiosInstance.get).toHaveBeenCalledWith('/dashboard-summary/'));
+
+    const receivablesLabel = await screen.findByText('Receivables');
+    const receivablesSection = receivablesLabel.closest('div').parentElement;
+    expect(within(receivablesSection).getByText('USD')).toBeInTheDocument();
+    expect(within(receivablesSection).getByText('EUR')).toBeInTheDocument();
+
+    const expensesLabel = screen.getByText('Expenses');
+    const expensesSection = expensesLabel.closest('div').parentElement;
+    expect(within(expensesSection).getByText('USD')).toBeInTheDocument();
+
+    const turnoverLabel = screen.getByText('Turnover');
+    const turnoverSection = turnoverLabel.closest('div').parentElement;
+    expect(within(turnoverSection).getByText('EUR')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- compute currency-aware breakdowns for receivables, payables, turnover, expenses, stock, and daily metrics in the dashboard summary response
- cover the dashboard summary API with a dedicated test exercising multi-currency data
- pass the new breakdown data through the dashboard UI and verify the breakdown rendering in a React test

## Testing
- python manage.py test *(fails: database connection refused in this environment)*
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68cb00309f20832392663a39b336dec1