### PR TITLE
Group report links and add customer balances report

### DIFF
--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -6,27 +6,27 @@ from rest_framework import serializers
 from decimal import Decimal
 from .exchange_rates import get_exchange_rate
 from .models import (
+    Activity,
+    BankAccount,
+    BankAccountTransaction,
+    CompanyInfo,
+    CompanySettings,
     Customer,
+    Expense,
     ExpenseCategory,
-    Sale,
+    Offer,
+    OfferItem,
     Payment,
     Product,
-    SaleItem,
-    SaleReturn,
-    SaleReturnItem,
-    Supplier,
-    Expense,
     Purchase,
     PurchaseItem,
     PurchaseReturn,
     PurchaseReturnItem,
-    BankAccount,
-    BankAccountTransaction,
-    Activity,
-    Offer,
-    OfferItem,
-    CompanyInfo,
-    CompanySettings,
+    Sale,
+    SaleItem,
+    SaleReturn,
+    SaleReturnItem,
+    Supplier,
 )
 from rest_framework.validators import UniqueValidator
 
@@ -96,6 +96,26 @@ class CustomerSerializer(serializers.ModelSerializer):
             'image',
         ]
         read_only_fields = ['created_by']
+
+
+class CustomerBalanceReportSerializer(serializers.ModelSerializer):
+    """Serializer used by the customer balance report endpoint."""
+
+    balance = serializers.DecimalField(
+        source='open_balance', max_digits=12, decimal_places=2, read_only=True
+    )
+    status = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Customer
+        fields = ['id', 'name', 'email', 'phone', 'currency', 'balance', 'status']
+
+    def get_status(self, obj):
+        if obj.open_balance > 0:
+            return 'owes_us'
+        if obj.open_balance < 0:
+            return 'we_owe_them'
+        return 'settled'
 
 class PaymentSerializer(serializers.ModelSerializer):
     customer = serializers.CharField(source='customer.name', read_only=True)

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -10,7 +10,11 @@ from .views.auth import CreateUserView
 from .views.banking import BankAccountViewSet
 from .views.common import dashboard_summary, get_currency_options
 from .views.company import CompanyInfoViewSet, CompanySettingsViewSet
-from .views.customers import CustomerPaymentViewSet, CustomerViewSet
+from .views.customers import (
+    CustomerPaymentViewSet,
+    CustomerViewSet,
+    customer_balance_report,
+)
 from .views.expenses import ExpenseCategoryViewSet, ExpenseViewSet, profit_and_loss_report
 from .views.products import ProductViewSet
 from .views.purchases import PurchaseReturnViewSet, PurchaseViewSet
@@ -50,6 +54,7 @@ urlpatterns = [
     path('dashboard-summary/', dashboard_summary, name='dashboard-summary'),
     path('auth/register/', CreateUserView.as_view(), name='register'),
     path('reports/profit-loss/', profit_and_loss_report, name='profit-loss-report'),
+    path('reports/customer-balances/', customer_balance_report, name='customer-balance-report'),
     path('reports/sales/', sales_report, name='sales-report'),
     path('', include(router.urls)),
     path('', include(sales_router.urls)),

--- a/backend/api/views/__init__.py
+++ b/backend/api/views/__init__.py
@@ -5,7 +5,11 @@ from .auth import CreateUserView
 from .banking import BankAccountViewSet
 from .common import dashboard_summary, get_currency_options
 from .company import CompanyInfoViewSet, CompanySettingsViewSet
-from .customers import CustomerPaymentViewSet, CustomerViewSet
+from .customers import (
+    CustomerPaymentViewSet,
+    CustomerViewSet,
+    customer_balance_report,
+)
 from .expenses import ExpenseCategoryViewSet, ExpenseViewSet, profit_and_loss_report
 from .products import ProductViewSet
 from .purchases import PurchaseReturnViewSet, PurchaseViewSet
@@ -40,5 +44,6 @@ __all__ = [
     'dashboard_summary',
     'get_currency_options',
     'profit_and_loss_report',
+    'customer_balance_report',
     'sales_report',
 ]

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -22,6 +22,7 @@ import SaleDetailPage from './pages/SaleDetailPage';
 import ExpenseListPage from './pages/ExpenseListPage';
 import ProfitLossPage from './pages/ProfitLossPage';
 import SalesReportPage from './pages/SalesReportPage';
+import CustomerBalanceReportPage from './pages/CustomerBalanceReportPage';
 import PurchaseFormPage from './pages/PurchaseFormPage';
 import EditSalePage from './pages/EditSalePage';
 import PurchaseListPage from './pages/PurchaseListPage';
@@ -79,6 +80,7 @@ function App() {
                   <Route path="expenses" element={<ExpenseListPage />} /> {/* <-- Add Route */}
                   <Route path="reports/profit-loss" element={<ProfitLossPage />} />
                   <Route path="reports/sales" element={<SalesReportPage />} />
+                  <Route path="reports/customer-balances" element={<CustomerBalanceReportPage />} />
                   <Route path="sales/:id/edit" element={<EditSalePage />} /> {/* <-- Add Route */}
                   <Route path="purchases" element={<PurchaseListPage />} /> {/* <-- Add Route */}
                   <Route path="purchases/:id" element={<PurchaseDetailPage />} /> {/* <-- Add Route */}

--- a/frontend/src/pages/CustomerBalanceReportPage.js
+++ b/frontend/src/pages/CustomerBalanceReportPage.js
@@ -1,0 +1,208 @@
+// frontend/src/pages/CustomerBalanceReportPage.js
+
+import React, { useEffect, useState } from 'react';
+import axiosInstance from '../utils/axiosInstance';
+import {
+    Card,
+    Spinner,
+    Alert,
+    Table,
+    Button,
+    Row,
+    Col,
+    Badge,
+} from 'react-bootstrap';
+import { formatCurrency } from '../utils/format';
+
+function CustomerBalanceReportPage() {
+    const [reportData, setReportData] = useState([]);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState('');
+
+    const loadReport = async () => {
+        setLoading(true);
+        setError('');
+        try {
+            const response = await axiosInstance.get('/reports/customer-balances/');
+            const data = Array.isArray(response.data) ? response.data : [];
+            setReportData(data);
+        } catch (err) {
+            console.error('Failed to load customer balance report:', err);
+            setError('Could not load the customer balance report. Please try again.');
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        loadReport();
+    }, []);
+
+    const counts = reportData.reduce(
+        (acc, customer) => {
+            const balance = Number(customer.balance);
+            if (balance > 0) {
+                acc.oweUs += 1;
+            } else if (balance < 0) {
+                acc.weOwe += 1;
+            } else {
+                acc.settled += 1;
+            }
+            return acc;
+        },
+        { oweUs: 0, weOwe: 0, settled: 0 }
+    );
+
+    const currencySummary = reportData.reduce((acc, customer) => {
+        const currency = customer.currency || 'USD';
+        const balance = Number(customer.balance);
+        if (!acc[currency]) {
+            acc[currency] = { oweUs: 0, weOwe: 0 };
+        }
+        if (balance > 0) {
+            acc[currency].oweUs += balance;
+        } else if (balance < 0) {
+            acc[currency].weOwe += Math.abs(balance);
+        }
+        return acc;
+    }, {});
+
+    const renderCurrencySummary = (type) => {
+        const entries = Object.entries(currencySummary).filter(([, totals]) => totals[type] > 0);
+        if (entries.length === 0) {
+            return <div className="small text-white-50">No balance</div>;
+        }
+        return entries.map(([currency, totals]) => (
+            <div key={`${type}-${currency}`} className="small">
+                {formatCurrency(totals[type], currency)}
+            </div>
+        ));
+    };
+
+    const getStatusVariant = (balance) => {
+        if (balance > 0) {
+            return 'danger';
+        }
+        if (balance < 0) {
+            return 'success';
+        }
+        return 'secondary';
+    };
+
+    const getStatusLabel = (balance) => {
+        if (balance > 0) {
+            return 'Owes us';
+        }
+        if (balance < 0) {
+            return 'We owe them';
+        }
+        return 'Settled';
+    };
+
+    return (
+        <Card>
+            <Card.Header className="d-flex justify-content-between align-items-center">
+                <h4 className="mb-0">Customer Balance Report</h4>
+                <Button variant="primary" onClick={loadReport} disabled={loading}>
+                    {loading ? (
+                        <>
+                            <Spinner as="span" animation="border" size="sm" role="status" className="me-2" />
+                            Refreshing
+                        </>
+                    ) : (
+                        'Refresh'
+                    )}
+                </Button>
+            </Card.Header>
+            <Card.Body>
+                {error && <Alert variant="danger">{error}</Alert>}
+                {loading && reportData.length === 0 ? (
+                    <div className="text-center py-5">
+                        <Spinner animation="border" role="status" />
+                    </div>
+                ) : (
+                    <>
+                        <Row className="mb-4">
+                            <Col md={4} className="mb-3">
+                                <Card bg="danger" text="white" className="h-100">
+                                    <Card.Body>
+                                        <Card.Title className="text-uppercase fs-6">Customers Owing Us</Card.Title>
+                                        <div className="display-6">{counts.oweUs}</div>
+                                        {renderCurrencySummary('oweUs')}
+                                    </Card.Body>
+                                </Card>
+                            </Col>
+                            <Col md={4} className="mb-3">
+                                <Card bg="success" text="white" className="h-100">
+                                    <Card.Body>
+                                        <Card.Title className="text-uppercase fs-6">Customers We Owe</Card.Title>
+                                        <div className="display-6">{counts.weOwe}</div>
+                                        {renderCurrencySummary('weOwe')}
+                                    </Card.Body>
+                                </Card>
+                            </Col>
+                            <Col md={4} className="mb-3">
+                                <Card bg="secondary" text="white" className="h-100">
+                                    <Card.Body>
+                                        <Card.Title className="text-uppercase fs-6">Settled Customers</Card.Title>
+                                        <div className="display-6">{counts.settled}</div>
+                                        <div className="small text-white-50">No outstanding balance</div>
+                                    </Card.Body>
+                                </Card>
+                            </Col>
+                        </Row>
+                        <Table striped bordered hover responsive>
+                            <thead>
+                                <tr>
+                                    <th>Name</th>
+                                    <th>Contact</th>
+                                    <th>Currency</th>
+                                    <th className="text-end">Balance</th>
+                                    <th>Status</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {reportData.length === 0 ? (
+                                    <tr>
+                                        <td colSpan="5" className="text-center py-4 text-muted">
+                                            No customer balances to display.
+                                        </td>
+                                    </tr>
+                                ) : (
+                                    reportData.map((customer) => {
+                                        const balanceValue = Number(customer.balance);
+                                        const balanceClass =
+                                            balanceValue > 0
+                                                ? 'text-danger'
+                                                : balanceValue < 0
+                                                ? 'text-success'
+                                                : 'text-muted';
+                                        return (
+                                            <tr key={customer.id}>
+                                                <td>{customer.name}</td>
+                                                <td>
+                                                    {customer.email ? <div>{customer.email}</div> : null}
+                                                    {customer.phone ? <div>{customer.phone}</div> : null}
+                                                    {!customer.email && !customer.phone && <span className="text-muted">—</span>}
+                                                </td>
+                                                <td>{customer.currency || 'USD'}</td>
+                                                <td className={`text-end ${balanceClass}`}>
+                                                    {formatCurrency(customer.balance, customer.currency || 'USD')}
+                                                </td>
+                                                <td>
+                                                    <Badge bg={getStatusVariant(balanceValue)}>{getStatusLabel(balanceValue)}</Badge>
+                                                </td>
+                                            </tr>
+                                        );
+                                    })
+                                )}
+                            </tbody>
+                        </Table>
+                    </>
+                )}
+            </Card.Body>
+        </Card>
+    );
+}
+
+export default CustomerBalanceReportPage;


### PR DESCRIPTION
## Summary
- add a serializer and API endpoint to expose a customer balance report
- group the report-related navigation links under a sidebar dropdown
- implement a Customer Balance Report page that consumes the new endpoint

## Testing
- python manage.py test *(fails: PostgreSQL server not available in container)*
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68cd2bf5e2048323ba42a3f67bbf1878