### PR TITLE
Improve reports navigation styling

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -47,3 +47,35 @@
   transform: translateY(-2px);
   box-shadow: 0 0.75rem 1.25rem rgba(0, 0, 0, 0.15);
 }
+
+.sidebar-submenu {
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 0.75rem;
+  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  border-left: 3px solid rgba(0, 184, 217, 0.55);
+  backdrop-filter: blur(2px);
+}
+
+.sidebar-submenu-collapsed {
+  box-shadow: 0 1rem 2rem rgba(0, 0, 0, 0.35);
+}
+
+.sidebar-submenu-link {
+  color: rgba(255, 255, 255, 0.75);
+  display: block;
+  text-decoration: none;
+  font-size: 0.95rem;
+  padding: 0.4rem 0.75rem;
+  border-radius: 0.5rem;
+  transition: color 0.2s ease, background-color 0.2s ease;
+}
+
+.sidebar-submenu-link:hover,
+.sidebar-submenu-link.active {
+  color: #ffffff;
+  background: rgba(0, 184, 217, 0.28);
+  font-weight: 600;
+}

--- a/frontend/src/components/AppLayout.js
+++ b/frontend/src/components/AppLayout.js
@@ -13,33 +13,14 @@ import {
     FileText,
     BoxSeam,
     BarChart,
+    PlusLg,
+    DashLg,
     Bank,
     BoxArrowRight,
     List,
     PersonCircle,
     Gear
 } from 'react-bootstrap-icons';
-
-const SidebarDropdownToggle = React.forwardRef(
-    ({ children, className = '', onClick, ...props }, ref) => (
-        <button
-            type="button"
-            ref={ref}
-            className={`${className} border-0 bg-transparent text-start w-100`}
-            onClick={(event) => {
-                event.preventDefault();
-                if (onClick) {
-                    onClick(event);
-                }
-            }}
-            {...props}
-        >
-            {children}
-        </button>
-    ),
-);
-
-SidebarDropdownToggle.displayName = 'SidebarDropdownToggle';
 
 function AppLayout({ children }) {
     const navigate = useNavigate();
@@ -70,9 +51,10 @@ function AppLayout({ children }) {
     const linkClass = `text-white w-100 d-flex ${collapsed ? 'justify-content-center' : 'align-items-center'} mb-2`;
     const iconClass = collapsed ? '' : 'me-2';
     const sidebarWidth = collapsed ? '80px' : '250px';
-    const reportsToggleClass = `${linkClass} text-decoration-none ${isReportsRoute ? 'bg-secondary bg-opacity-50 rounded' : ''}`;
-    const reportsMenuClass = `${collapsed ? '' : 'w-100 px-0'} border-0 shadow-sm`;
-    const reportsMenuStyle = collapsed ? undefined : { position: 'static', float: 'none' };
+    const reportsToggleActive = isReportsRoute || reportsOpen;
+    const reportsToggleClass = `text-white w-100 d-flex ${
+        collapsed ? 'justify-content-center' : 'align-items-center justify-content-between'
+    } mb-2 text-decoration-none px-2 py-2 rounded ${reportsToggleActive ? 'bg-secondary bg-opacity-50' : ''}`;
 
     const SidebarContent = (
         <>
@@ -102,47 +84,53 @@ function AppLayout({ children }) {
                 <Nav.Link as={NavLink} to="/inventory" className={linkClass}>
                     <BoxSeam className={iconClass} /> {!collapsed && 'Inventory'}
                 </Nav.Link>
-                <Dropdown
-                    show={reportsOpen}
-                    onToggle={(isOpen) => setReportsOpen(isOpen)}
-                    drop={collapsed ? 'end' : 'down'}
-                >
-                    <Dropdown.Toggle
-                        as={SidebarDropdownToggle}
-                        id="reports-nav-dropdown"
-                        className={reportsToggleClass}
+                <div className="position-relative">
+                    <button
+                        type="button"
+                        className={`${reportsToggleClass} border-0 bg-transparent`}
+                        onClick={() => setReportsOpen((prev) => !prev)}
                     >
-                        <BarChart className={iconClass} /> {!collapsed && 'Reports'}
-                    </Dropdown.Toggle>
-                    <Dropdown.Menu
-                        align={collapsed ? 'end' : 'start'}
-                        menuVariant="dark"
-                        className={reportsMenuClass}
-                        style={reportsMenuStyle}
-                    >
-                        <Dropdown.Item
-                            as={NavLink}
-                            to="/reports/profit-loss"
-                            className={`${!collapsed ? 'ps-4' : ''} text-white`}
+                        <span className="d-flex align-items-center">
+                            <BarChart className={iconClass} /> {!collapsed && 'Reports'}
+                        </span>
+                        {!collapsed && (reportsOpen ? <DashLg size={18} /> : <PlusLg size={18} />)}
+                    </button>
+                    {reportsOpen && (
+                        <div
+                            className={`sidebar-submenu ${
+                                collapsed
+                                    ? 'sidebar-submenu-collapsed position-absolute start-100 top-0 ms-2'
+                                    : 'mt-2 ms-2 w-100'
+                            }`}
+                            style={collapsed ? { minWidth: '220px', zIndex: 1050 } : {}}
                         >
-                            Profit &amp; Loss
-                        </Dropdown.Item>
-                        <Dropdown.Item
-                            as={NavLink}
-                            to="/reports/sales"
-                            className={`${!collapsed ? 'ps-4' : ''} text-white`}
-                        >
-                            Sales Report
-                        </Dropdown.Item>
-                        <Dropdown.Item
-                            as={NavLink}
-                            to="/reports/customer-balances"
-                            className={`${!collapsed ? 'ps-4' : ''} text-white`}
-                        >
-                            Customer Balances
-                        </Dropdown.Item>
-                    </Dropdown.Menu>
-                </Dropdown>
+                            <NavLink
+                                to="/reports/profit-loss"
+                                className={({ isActive }) =>
+                                    `sidebar-submenu-link ${isActive ? 'active' : ''}`
+                                }
+                            >
+                                Profit &amp; Loss
+                            </NavLink>
+                            <NavLink
+                                to="/reports/sales"
+                                className={({ isActive }) =>
+                                    `sidebar-submenu-link ${isActive ? 'active' : ''}`
+                                }
+                            >
+                                Sales Report
+                            </NavLink>
+                            <NavLink
+                                to="/reports/customer-balances"
+                                className={({ isActive }) =>
+                                    `sidebar-submenu-link ${isActive ? 'active' : ''}`
+                                }
+                            >
+                                Customer Balances
+                            </NavLink>
+                        </div>
+                    )}
+                </div>
                 <Nav.Link as={NavLink} to="/accounts" className={linkClass}>
                     <Bank className={iconClass} /> {!collapsed && 'Bank Accounts'}
                 </Nav.Link>


### PR DESCRIPTION
## Summary
- replace the Reports nav dropdown with a custom collapsible list that shows a plus/minus toggle and works in both expanded and collapsed sidebars
- style the Reports submenu with a dark theme background and hover states so the links remain visible and aligned with the desired design

## Testing
- CI=true npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68cd31c2c6d083239be673c4716fd3ea