### PR TITLE
Restyle report submenu links

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -51,31 +51,34 @@
 .sidebar-submenu {
   background: rgba(255, 255, 255, 0.08);
   border-radius: 0.75rem;
-  padding: 0.75rem;
+  padding: 0.35rem;
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
-  border-left: 3px solid rgba(0, 184, 217, 0.55);
+  gap: 0.25rem;
   backdrop-filter: blur(2px);
 }
 
 .sidebar-submenu-collapsed {
   box-shadow: 0 1rem 2rem rgba(0, 0, 0, 0.35);
+  padding: 0.5rem;
 }
 
 .sidebar-submenu-link {
-  color: rgba(255, 255, 255, 0.75);
-  display: block;
+  color: rgba(248, 249, 250, 0.85);
+  display: flex;
+  align-items: center;
+  width: 100%;
   text-decoration: none;
   font-size: 0.95rem;
-  padding: 0.4rem 0.75rem;
+  font-weight: 500;
+  padding: 0.45rem 0.75rem;
   border-radius: 0.5rem;
-  transition: color 0.2s ease, background-color 0.2s ease;
+  transition: background-color 0.2s ease, color 0.2s ease;
 }
 
 .sidebar-submenu-link:hover,
 .sidebar-submenu-link.active {
   color: #ffffff;
-  background: rgba(0, 184, 217, 0.28);
-  font-weight: 600;
+  background: rgba(255, 255, 255, 0.18);
+  text-decoration: none;
 }

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -2,6 +2,7 @@
 
 import React, { useEffect } from 'react';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
+import './App.css';
 import LoginPage from './pages/LoginPage';
 import RegisterPage from './pages/RegisterPage';
 import DashboardPage from './pages/DashboardPage';


### PR DESCRIPTION
## Summary
- import the global stylesheet into the app so shared styles apply to layout components
- restyle the report submenu links to match the main navigation appearance without underlines

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd5d9628e88323a4d658a1a1a149b0