### PR TITLE
Fix sales report row collapse behavior

### DIFF
--- a/frontend/src/pages/SalesReportPage.js
+++ b/frontend/src/pages/SalesReportPage.js
@@ -46,8 +46,17 @@ function SalesReportPage() {
             setLoading(false);
         }
     };
+    const openRow = (id) => {
+        setOpenRows(prev => ({ ...prev, [id]: true }));
+    };
+
     const toggleRow = (id) => {
         setOpenRows(prev => ({ ...prev, [id]: !prev[id] }));
+    };
+
+    const handleToggleClick = (event, id) => {
+        event.stopPropagation();
+        toggleRow(id);
     };
 
     return (
@@ -103,8 +112,16 @@ function SalesReportPage() {
                             <tbody>
                                 {reportData.map((sale) => (
                                     <React.Fragment key={sale.id}>
-                                        <tr onClick={() => toggleRow(sale.id)} style={{ cursor: 'pointer' }}>
-                                            <td><Button variant="link" size="sm">{openRows[sale.id] ? '-' : '+'}</Button></td>
+                                        <tr onClick={() => openRow(sale.id)} style={{ cursor: 'pointer' }}>
+                                            <td>
+                                                <Button
+                                                    variant="link"
+                                                    size="sm"
+                                                    onClick={(event) => handleToggleClick(event, sale.id)}
+                                                >
+                                                    {openRows[sale.id] ? '-' : '+'}
+                                                </Button>
+                                            </td>
                                             <td>{sale.sale_date}</td>
                                             <td>{sale.invoice_number}</td>
                                             <td>{sale.customer_name}</td>


### PR DESCRIPTION
## Summary
- ensure sales report rows open on selection and stay open until the toggle button is clicked
- stop the toggle control click from bubbling so the minus button is the only way to close details

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68cd9630f0e483239b15b463b61e1b3c