### PR TITLE
Fix report export downloads by using export_format parameter

### DIFF
--- a/backend/api/tests/test_report_exports.py
+++ b/backend/api/tests/test_report_exports.py
@@ -1,6 +1,6 @@
 """Tests covering PDF and Excel exports for accounting reports."""
 
-from datetime import date
+from datetime import date, timedelta
 from decimal import Decimal
 from io import BytesIO
 
@@ -28,6 +28,7 @@ class ReportExportTests(TestCase):
         )
         self.sale.refresh_from_db()
         self.sale_date = self.sale.sale_date
+        self.report_end_date = (self.sale_date + timedelta(days=1)).strftime("%Y-%m-%d")
 
         Customer.objects.create(
             name="Globex", created_by=self.user, currency="EUR", open_balance=Decimal("-25.00")
@@ -54,8 +55,8 @@ class ReportExportTests(TestCase):
             "/api/reports/sales/",
             {
                 "start_date": "2023-01-01",
-                "end_date": "2025-01-01",
-                "format": "xlsx",
+                "end_date": self.report_end_date,
+                "export_format": "xlsx",
             },
         )
 
@@ -80,8 +81,8 @@ class ReportExportTests(TestCase):
             "/api/reports/sales/",
             {
                 "start_date": "2023-01-01",
-                "end_date": "2025-01-01",
-                "format": "pdf",
+                "end_date": self.report_end_date,
+                "export_format": "pdf",
             },
         )
 
@@ -92,8 +93,8 @@ class ReportExportTests(TestCase):
             "/api/reports/profit-loss/",
             {
                 "start_date": "2023-01-01",
-                "end_date": "2025-01-01",
-                "format": "xlsx",
+                "end_date": self.report_end_date,
+                "export_format": "xlsx",
             },
         )
 
@@ -117,8 +118,8 @@ class ReportExportTests(TestCase):
             "/api/reports/profit-loss/",
             {
                 "start_date": "2023-01-01",
-                "end_date": "2025-01-01",
-                "format": "pdf",
+                "end_date": self.report_end_date,
+                "export_format": "pdf",
             },
         )
 
@@ -128,7 +129,7 @@ class ReportExportTests(TestCase):
         response = self.client.get(
             "/api/reports/customer-balances/",
             {
-                "format": "xlsx",
+                "export_format": "xlsx",
             },
         )
 
@@ -170,7 +171,7 @@ class ReportExportTests(TestCase):
         response = self.client.get(
             "/api/reports/customer-balances/",
             {
-                "format": "pdf",
+                "export_format": "pdf",
             },
         )
 

--- a/backend/api/views/customers.py
+++ b/backend/api/views/customers.py
@@ -122,7 +122,10 @@ def customer_balance_report(request):
     serializer = CustomerBalanceReportSerializer(queryset, many=True)
     data = serializer.data
 
-    export_format = request.query_params.get('format', '').lower()
+    export_format = request.query_params.get('export_format')
+    if not export_format:
+        export_format = request.query_params.get('format')
+    export_format = (export_format or '').lower()
     filename_stub = 'customer-balance-report'
 
     if export_format in {'xlsx', 'excel'}:

--- a/backend/api/views/expenses.py
+++ b/backend/api/views/expenses.py
@@ -108,7 +108,10 @@ def profit_and_loss_report(request):
         'expenses_breakdown': list(expenses_by_category),
     }
 
-    export_format = request.query_params.get('format', '').lower()
+    export_format = request.query_params.get('export_format')
+    if not export_format:
+        export_format = request.query_params.get('format')
+    export_format = (export_format or '').lower()
     filename_stub = f"profit-loss-report-{start_date_str}-to-{end_date_str}".replace(' ', '_')
 
     if export_format in {'xlsx', 'excel'}:

--- a/backend/api/views/sales.py
+++ b/backend/api/views/sales.py
@@ -249,7 +249,10 @@ def sales_report(request):
     start_date_str = request.query_params.get('start_date', '2000-01-01')
     end_date_str = request.query_params.get('end_date', date.today().strftime('%Y-%m-%d'))
 
-    export_format = request.query_params.get('format', '').lower()
+    export_format = request.query_params.get('export_format')
+    if not export_format:
+        export_format = request.query_params.get('format')
+    export_format = (export_format or '').lower()
 
     sales_in_range = list(
         Sale.objects.filter(

--- a/frontend/src/pages/CustomerBalanceReportPage.js
+++ b/frontend/src/pages/CustomerBalanceReportPage.js
@@ -42,7 +42,7 @@ function CustomerBalanceReportPage() {
         setExportingFormat(format);
         try {
             const response = await axiosInstance.get('/reports/customer-balances/', {
-                params: { format },
+                params: { export_format: format },
                 responseType: 'blob',
             });
             const extension = format === 'pdf' ? 'pdf' : 'xlsx';

--- a/frontend/src/pages/ProfitLossPage.js
+++ b/frontend/src/pages/ProfitLossPage.js
@@ -60,7 +60,7 @@ function ProfitLossPage() {
             const params = {
                 start_date: startDate,
                 end_date: endDate,
-                format,
+                export_format: format,
             };
             const response = await axiosInstance.get('/reports/profit-loss/', {
                 params,

--- a/frontend/src/pages/SalesReportPage.js
+++ b/frontend/src/pages/SalesReportPage.js
@@ -58,7 +58,7 @@ function SalesReportPage() {
             const params = {
                 start_date: startDate,
                 end_date: endDate,
-                format,
+                export_format: format,
             };
             const response = await axiosInstance.get('/reports/sales/', {
                 params,


### PR DESCRIPTION
## Summary
- update sales, profit/loss, and customer balance report endpoints to read an export_format query parameter while still tolerating the old name
- switch the React report pages to send export_format so exports are returned instead of DRF treating format as a renderer hint
- refresh report export tests to use the new parameter and ensure date ranges include the generated sale

## Testing
- npm test -- --watchAll=false
- python - <<'PY'
import os, sys
sys.path.append('backend')
os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'core.settings')
from django.conf import settings
settings.DATABASES['default'] = {
    'ENGINE': 'django.db.backends.sqlite3',
    'NAME': ':memory:',
}
import django
django.setup()
from django.core.management import call_command
call_command('test', 'api.tests.test_report_exports')
PY


------
https://chatgpt.com/codex/tasks/task_e_68cda78457b08323891be90c71f1c02d