### PR TITLE
Add shared theme styling and align button colors

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -48,37 +48,3 @@
   box-shadow: 0 0.75rem 1.25rem rgba(0, 0, 0, 0.15);
 }
 
-.sidebar-submenu {
-  background: rgba(255, 255, 255, 0.08);
-  border-radius: 0.75rem;
-  padding: 0.35rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-  backdrop-filter: blur(2px);
-}
-
-.sidebar-submenu-collapsed {
-  box-shadow: 0 1rem 2rem rgba(0, 0, 0, 0.35);
-  padding: 0.5rem;
-}
-
-.sidebar-submenu-link {
-  color: rgba(248, 249, 250, 0.85);
-  display: flex;
-  align-items: center;
-  width: 100%;
-  text-decoration: none;
-  font-size: 0.95rem;
-  font-weight: 500;
-  padding: 0.45rem 0.75rem;
-  border-radius: 0.5rem;
-  transition: background-color 0.2s ease, color 0.2s ease;
-}
-
-.sidebar-submenu-link:hover,
-.sidebar-submenu-link.active {
-  color: #ffffff;
-  background: rgba(255, 255, 255, 0.18);
-  text-decoration: none;
-}

--- a/frontend/src/components/AppLayout.js
+++ b/frontend/src/components/AppLayout.js
@@ -48,13 +48,15 @@ function AppLayout({ children }) {
     };
 
     const isReportsRoute = location.pathname.startsWith('/reports');
-    const linkClass = `text-white w-100 d-flex ${collapsed ? 'justify-content-center' : 'align-items-center'} mb-2`;
+    const linkClass = `app-nav-link w-100 d-flex gap-2 ${
+        collapsed ? 'justify-content-center' : 'align-items-center'
+    } mb-2`;
     const iconClass = collapsed ? '' : 'me-2';
     const sidebarWidth = collapsed ? '80px' : '250px';
     const reportsToggleActive = isReportsRoute || reportsOpen;
-    const reportsToggleClass = `text-white w-100 d-flex ${
+    const reportsToggleClass = `app-nav-link w-100 d-flex ${
         collapsed ? 'justify-content-center' : 'align-items-center justify-content-between'
-    } mb-2 text-decoration-none px-2 py-2 rounded ${reportsToggleActive ? 'bg-secondary bg-opacity-50' : ''}`;
+    } gap-2 mb-2 ${reportsToggleActive ? 'active' : ''}`;
 
     const SidebarContent = (
         <>
@@ -87,10 +89,11 @@ function AppLayout({ children }) {
                 <div className="position-relative">
                     <button
                         type="button"
-                        className={`${reportsToggleClass} border-0 bg-transparent`}
+                        className={`${reportsToggleClass} border-0`}
                         onClick={() => setReportsOpen((prev) => !prev)}
+                        aria-expanded={reportsOpen}
                     >
-                        <span className="d-flex align-items-center">
+                        <span className="d-flex align-items-center gap-2">
                             <BarChart className={iconClass} /> {!collapsed && 'Reports'}
                         </span>
                         {!collapsed && (reportsOpen ? <DashLg size={18} /> : <PlusLg size={18} />)}
@@ -141,7 +144,7 @@ function AppLayout({ children }) {
     return (
         <div>
             {isMobile ? (
-                <Offcanvas show={showSidebar} onHide={() => setShowSidebar(false)} className="bg-dark text-white">
+                <Offcanvas show={showSidebar} onHide={() => setShowSidebar(false)} className="app-sidebar">
                     <Offcanvas.Header closeButton closeVariant="white">
                         <Offcanvas.Title>MyAccountingApp</Offcanvas.Title>
                     </Offcanvas.Header>
@@ -149,7 +152,7 @@ function AppLayout({ children }) {
                 </Offcanvas>
             ) : (
                 <div
-                    className="bg-dark text-white d-flex flex-column p-3"
+                    className="app-sidebar d-flex flex-column p-3"
                     style={{
                         width: sidebarWidth,
                         minHeight: '100vh',
@@ -167,9 +170,9 @@ function AppLayout({ children }) {
                 className="d-flex flex-column"
                 style={{ marginLeft: isMobile ? 0 : sidebarWidth, transition: 'margin-left 0.3s', minHeight: '100vh' }}
             >
-                <div className="d-flex justify-content-between align-items-center border-bottom p-3">
+                <div className="app-header d-flex justify-content-between align-items-center">
                     <Button
-                        variant="light"
+                        variant="ghost"
                         size="sm"
                         className="border-0 shadow-none"
                         onClick={() => (isMobile ? setShowSidebar(true) : setCollapsed(!collapsed))}
@@ -178,11 +181,11 @@ function AppLayout({ children }) {
                     </Button>
                     <Dropdown align="end">
                         <Dropdown.Toggle
-                            variant="light"
+                            variant="ghost"
                             id="user-dropdown"
-                            className="border-0 bg-transparent d-flex align-items-center"
+                            className="d-flex align-items-center gap-2"
                         >
-                            <PersonCircle size={32} className="me-2" />
+                            <PersonCircle size={32} className="flex-shrink-0" />
                             {username}
                         </Dropdown.Toggle>
                         <Dropdown.Menu>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -14,23 +14,23 @@ code {
 
 /* Provide a consistent elevated appearance for all cards */
 .card {
-  border: 1px solid rgba(15, 23, 42, 0.08);
+  border: 1px solid var(--border-subtle);
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .card:not(.shadow-none) {
-  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+  box-shadow: var(--shadow-sm);
 }
 
 .card:not(.shadow-none):hover {
   transform: translateY(-2px);
-  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.12);
+  box-shadow: var(--shadow-md);
 }
 
 .card.shadow-sm {
-  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08) !important;
+  box-shadow: var(--shadow-sm) !important;
 }
 
 .card.shadow-sm:hover {
-  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.12) !important;
+  box-shadow: var(--shadow-md) !important;
 }

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import './index.css';
+import './styles/theme.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
 

--- a/frontend/src/pages/CustomerListPage.js
+++ b/frontend/src/pages/CustomerListPage.js
@@ -67,13 +67,13 @@ function CustomerListPage() {
             <Row className="mb-3 align-items-center">
                 <Col md={6}>
                     <div className="d-flex">
-                        <Button variant="success" className="me-2" onClick={() => navigate('/customers/new')}>
+                        <Button variant="primary" className="me-2" onClick={() => navigate('/customers/new')}>
                             <Plus size={20} className="me-1" /> Add New Customer
                         </Button>
-                        <Button variant="warning" className="me-2">
+                        <Button variant="outline" className="me-2">
                             <Upload size={20} className="me-1" /> Upload from Excel
                         </Button>
-                        <Button variant="info">
+                        <Button variant="accent">
                             <Wrench size={20} className="me-1" /> Bulk Update Customers
                         </Button>
                     </div>

--- a/frontend/src/pages/SaleListPage.js
+++ b/frontend/src/pages/SaleListPage.js
@@ -66,7 +66,7 @@ function SaleListPage() {
                                     <td>{new Date(sale.sale_date).toLocaleDateString()}</td>
                                     <td>{formatCurrency(sale.total_amount, sale.original_currency || 'USD')}</td>
                                     <td>
-                                        <Button as={Link} to={`/sales/${sale.id}`} variant="info" size="sm">
+                                        <Button as={Link} to={`/sales/${sale.id}`} variant="outline" size="sm">
                                         View
                                     </Button>
                                     </td>

--- a/frontend/src/styles/theme.css
+++ b/frontend/src/styles/theme.css
@@ -1,0 +1,226 @@
+:root {
+  --color-primary: #2563eb;
+  --color-primary-hover: #1d4ed8;
+  --color-secondary: #1e293b;
+  --color-secondary-hover: #334155;
+  --color-accent: #f97316;
+  --color-accent-hover: #ea580c;
+  --color-surface: #0f172a;
+  --color-surface-elevated: #142044;
+  --color-surface-muted: rgba(15, 23, 42, 0.65);
+  --color-neutral-50: #f8fafc;
+  --color-neutral-100: #f1f5f9;
+  --color-neutral-200: #e2e8f0;
+  --color-neutral-400: #94a3b8;
+  --color-neutral-500: #64748b;
+  --color-neutral-700: #334155;
+  --color-neutral-900: #0f172a;
+  --text-primary: #f8fafc;
+  --text-secondary: rgba(226, 232, 240, 0.72);
+  --text-inverse: #0f172a;
+  --border-subtle: rgba(148, 163, 184, 0.18);
+  --border-strong: rgba(37, 99, 235, 0.35);
+  --sidebar-hover-bg: rgba(37, 99, 235, 0.16);
+  --sidebar-active-bg: rgba(37, 99, 235, 0.24);
+  --sidebar-pill: rgba(148, 163, 184, 0.22);
+  --shadow-sm: 0 8px 24px rgba(15, 23, 42, 0.12);
+  --shadow-md: 0 16px 40px rgba(15, 23, 42, 0.16);
+  --shadow-lg: 0 26px 70px rgba(15, 23, 42, 0.22);
+  --focus-ring: 0 0 0 0.2rem rgba(37, 99, 235, 0.35);
+}
+
+body {
+  background: var(--color-neutral-100);
+  color: var(--color-neutral-900);
+}
+
+.app-sidebar {
+  background: var(--color-surface);
+  color: var(--text-secondary);
+  box-shadow: var(--shadow-sm);
+  border-right: 1px solid var(--color-surface-muted);
+}
+
+.app-sidebar h4 {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+.app-sidebar .nav {
+  gap: 0.25rem;
+}
+
+.app-nav-link {
+  background: transparent;
+  color: var(--text-secondary);
+  border-radius: 0.9rem;
+  padding: 0.6rem 0.75rem;
+  font-weight: 500;
+  transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.app-nav-link svg {
+  flex-shrink: 0;
+}
+
+.app-nav-link:hover,
+.app-nav-link:focus {
+  color: var(--text-primary);
+  background: var(--sidebar-hover-bg);
+  text-decoration: none;
+}
+
+.app-nav-link.active,
+.app-nav-link.active:hover,
+.app-nav-link.active:focus,
+.app-nav-link.is-active {
+  color: var(--text-primary);
+  background: var(--sidebar-active-bg);
+  box-shadow: inset 0 0 0 1px var(--border-strong);
+}
+
+.sidebar-submenu {
+  background: var(--color-surface-elevated);
+  border-radius: 0.9rem;
+  padding: 0.4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  box-shadow: inset 0 0 0 1px var(--color-surface-muted);
+}
+
+.sidebar-submenu-collapsed {
+  box-shadow: var(--shadow-md);
+}
+
+.sidebar-submenu-link {
+  color: var(--text-secondary);
+  display: flex;
+  align-items: center;
+  width: 100%;
+  text-decoration: none;
+  font-size: 0.95rem;
+  font-weight: 500;
+  padding: 0.45rem 0.75rem;
+  border-radius: 0.65rem;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.sidebar-submenu-link:hover,
+.sidebar-submenu-link.active {
+  color: var(--text-primary);
+  background: var(--sidebar-hover-bg);
+  text-decoration: none;
+}
+
+.app-header {
+  background: var(--color-neutral-50);
+  color: var(--color-neutral-900);
+  border-bottom: 1px solid var(--border-subtle);
+  padding: 0.85rem 1.75rem;
+  box-shadow: 0 1px 0 rgba(15, 23, 42, 0.04);
+}
+
+.app-header .dropdown-toggle {
+  color: var(--color-neutral-700);
+}
+
+.app-header .dropdown-toggle:hover,
+.app-header .dropdown-toggle:focus {
+  color: var(--color-neutral-900);
+  background: rgba(148, 163, 184, 0.12);
+}
+
+.btn {
+  border-radius: 0.75rem;
+  font-weight: 600;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease, color 0.2s ease;
+}
+
+.btn:focus,
+.btn:focus-visible {
+  box-shadow: var(--focus-ring);
+}
+
+.btn-primary {
+  background: var(--color-primary);
+  border-color: var(--color-primary);
+  color: var(--text-primary);
+  box-shadow: 0 10px 24px rgba(37, 99, 235, 0.24);
+}
+
+.btn-primary:hover,
+.btn-primary:focus {
+  background: var(--color-primary-hover);
+  border-color: var(--color-primary-hover);
+  color: var(--text-primary);
+  transform: translateY(-1px);
+  box-shadow: 0 14px 32px rgba(37, 99, 235, 0.28);
+}
+
+.btn-accent {
+  background: var(--color-accent);
+  border-color: var(--color-accent);
+  color: var(--text-inverse);
+  box-shadow: 0 10px 24px rgba(249, 115, 22, 0.2);
+}
+
+.btn-accent:hover,
+.btn-accent:focus {
+  background: var(--color-accent-hover);
+  border-color: var(--color-accent-hover);
+  color: var(--text-inverse);
+  transform: translateY(-1px);
+  box-shadow: 0 14px 32px rgba(234, 88, 12, 0.24);
+}
+
+.btn-outline {
+  background: transparent;
+  border: 1px solid var(--color-primary);
+  color: var(--color-primary);
+  box-shadow: none;
+}
+
+.btn-outline:hover,
+.btn-outline:focus {
+  background: rgba(37, 99, 235, 0.1);
+  color: var(--color-primary-hover);
+  border-color: var(--color-primary-hover);
+  box-shadow: none;
+}
+
+.btn-ghost {
+  background: transparent;
+  border-color: transparent;
+  color: var(--color-neutral-700);
+  box-shadow: none;
+}
+
+.btn-ghost:hover,
+.btn-ghost:focus {
+  background: rgba(15, 23, 42, 0.06);
+  color: var(--color-neutral-900);
+  border-color: transparent;
+  box-shadow: none;
+}
+
+.offcanvas.app-sidebar {
+  background: var(--color-surface);
+  color: var(--text-primary);
+  border-right: 0;
+}
+
+.offcanvas.app-sidebar .offcanvas-body,
+.offcanvas.app-sidebar .offcanvas-header {
+  background: var(--color-surface);
+  color: var(--text-primary);
+}
+
+.offcanvas.app-sidebar .btn-close {
+  filter: invert(1);
+  opacity: 0.75;
+}
+
+.offcanvas.app-sidebar .btn-close:hover {
+  opacity: 1;
+}


### PR DESCRIPTION
## Summary
- add a shared theme stylesheet with color variables, sidebar/header styles, and custom button helpers
- refactor the main layout to rely on the new semantic classes and hover/active treatments
- update customer and sales list pages to adopt the shared button variants and reuse the theme shadows

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68ce49cf933483238a4196597aca8341