### PR TITLE
feat: introduce typography system and preload fonts

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -15,6 +15,54 @@
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="preload"
+      as="font"
+      type="font/woff2"
+      href="https://fonts.gstatic.com/s/inter/v20/UcCO3FwrK3iLTeHuS_nVMrMxCp50SjIw2boKoduKmMEVuLyfAZ9hiA.woff2"
+      crossorigin
+    />
+    <link
+      rel="preload"
+      as="font"
+      type="font/woff2"
+      href="https://fonts.gstatic.com/s/inter/v20/UcCO3FwrK3iLTeHuS_nVMrMxCp50SjIw2boKoduKmMEVuI6fAZ9hiA.woff2"
+      crossorigin
+    />
+    <link
+      rel="preload"
+      as="font"
+      type="font/woff2"
+      href="https://fonts.gstatic.com/s/inter/v20/UcCO3FwrK3iLTeHuS_nVMrMxCp50SjIw2boKoduKmMEVuGKYAZ9hiA.woff2"
+      crossorigin
+    />
+    <link
+      rel="preload"
+      as="font"
+      type="font/woff2"
+      href="https://fonts.gstatic.com/s/dmsans/v17/rP2tp2ywxg089UriI5-g4vlH9VoD8CmcqZG40F9JadbnoEwAopxRSW32.woff2"
+      crossorigin
+    />
+    <link
+      rel="preload"
+      as="font"
+      type="font/woff2"
+      href="https://fonts.gstatic.com/s/dmsans/v17/rP2tp2ywxg089UriI5-g4vlH9VoD8CmcqZG40F9JadbnoEwAkJxRSW32.woff2"
+      crossorigin
+    />
+    <link
+      rel="preload"
+      as="font"
+      type="font/woff2"
+      href="https://fonts.gstatic.com/s/dmsans/v17/rP2tp2ywxg089UriI5-g4vlH9VoD8CmcqZG40F9JadbnoEwAfJtRSW32.woff2"
+      crossorigin
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600&family=Inter:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,15 +1,131 @@
+:root {
+  --font-family-base: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans',
+    'Helvetica Neue', sans-serif;
+  --font-family-heading: 'DM Sans', 'Inter', -apple-system, BlinkMacSystemFont,
+    'Segoe UI', sans-serif;
+  --font-size-base: 16px;
+  --line-height-base: 1.6;
+  --text-color-primary: var(--color-neutral-900, #0f172a);
+  --text-color-secondary: var(--color-neutral-700, #334155);
+  --text-color-muted: var(--color-neutral-500, #64748b);
+  --text-color-subtle: var(--color-neutral-400, #94a3b8);
+  --background-soft: var(--color-neutral-50, #f8fafc);
+}
+
+html {
+  font-size: var(--font-size-base);
+}
+
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
+  font-family: var(--font-family-base);
+  font-size: 1rem;
+  line-height: var(--line-height-base);
+  background-color: var(--background-soft);
+  color: var(--text-color-primary);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+p,
+ul,
+ol {
+  color: var(--text-color-primary);
+  line-height: var(--line-height-base);
 }
 
 code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+.page-title,
+.section-subtitle {
+  margin-top: 0;
+  font-family: var(--font-family-heading);
+  color: var(--text-color-primary);
+}
+
+h1,
+.page-title {
+  font-weight: 600;
+  letter-spacing: -0.02em;
+}
+
+h1 {
+  font-size: clamp(2.5rem, 3vw + 1.5rem, 3.25rem);
+  line-height: 1.1;
+}
+
+.page-title {
+  font-size: clamp(2rem, 2.5vw + 1rem, 2.75rem);
+  line-height: 1.15;
+}
+
+h2 {
+  font-size: clamp(2rem, 2vw + 1.25rem, 2.5rem);
+  font-weight: 600;
+  line-height: 1.15;
+}
+
+h3 {
+  font-size: clamp(1.75rem, 1.5vw + 1.1rem, 2.125rem);
+  font-weight: 600;
+  line-height: 1.2;
+}
+
+h4 {
+  font-size: 1.5rem;
+  font-weight: 600;
+  line-height: 1.25;
+}
+
+h5 {
+  font-size: 1.25rem;
+  font-weight: 500;
+  line-height: 1.3;
+}
+
+h6 {
+  font-size: 1rem;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-color-secondary);
+  line-height: 1.4;
+}
+
+.section-subtitle {
+  font-size: 1rem;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-color-muted);
+}
+
+.text-muted,
+.text-muted-soft {
+  color: var(--text-color-muted) !important;
+}
+
+.text-subtle {
+  color: var(--text-color-subtle) !important;
+}
+
+.text-microcopy {
+  font-size: 0.75rem;
+  line-height: 1.4;
+  color: var(--text-color-subtle);
+  letter-spacing: 0.04em;
+  text-transform: none;
+  font-weight: 500;
 }
 
 /* Provide a consistent elevated appearance for all cards */

--- a/frontend/src/styles/theme.css
+++ b/frontend/src/styles/theme.css
@@ -30,8 +30,8 @@
 }
 
 body {
-  background: var(--color-neutral-100);
-  color: var(--color-neutral-900);
+  background-color: var(--background-soft);
+  color: var(--text-color-primary);
 }
 
 .app-sidebar {


### PR DESCRIPTION
## Summary
- preload Inter and DM Sans webfonts, including 400–600 weight preloads, via the HTML template
- define global typography tokens, body styling, heading scale, and muted text utilities in `index.css`
- align the theme body background and text colors with the new typography variables

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ce4d1b6bec8323b7777b26d9d09d49