### PR TITLE
Revamp login screen layout

### DIFF
--- a/frontend/src/pages/LoginPage.css
+++ b/frontend/src/pages/LoginPage.css
@@ -1,0 +1,252 @@
+.auth-layout {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(1.5rem, 5vw, 4rem);
+  background: linear-gradient(
+    180deg,
+    rgba(37, 99, 235, 0.08) 0%,
+    rgba(15, 23, 42, 0.12) 100%
+  );
+}
+
+.auth-card {
+  width: min(100%, 1080px);
+  display: grid;
+  grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr);
+  background: var(--color-neutral-50, #f8fafc);
+  border-radius: 1.75rem;
+  overflow: hidden;
+  box-shadow: var(--shadow-lg, 0 26px 70px rgba(15, 23, 42, 0.22));
+  border: 1px solid var(--border-subtle, rgba(148, 163, 184, 0.18));
+}
+
+.auth-hero {
+  position: relative;
+  display: flex;
+  align-items: flex-end;
+  padding: clamp(2rem, 5vw, 4.5rem);
+  color: var(--text-primary, #f8fafc);
+  background: linear-gradient(
+    135deg,
+    var(--color-primary, #2563eb) 0%,
+    rgba(37, 99, 235, 0.85) 38%,
+    var(--color-secondary, #1e293b) 100%
+  );
+  isolation: isolate;
+}
+
+.auth-hero::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+      circle at 18% 22%,
+      rgba(249, 115, 22, 0.35),
+      transparent 60%
+    ),
+    radial-gradient(circle at 82% 78%, rgba(148, 163, 184, 0.25), transparent 55%);
+  mix-blend-mode: screen;
+  opacity: 0.9;
+  z-index: 0;
+}
+
+.auth-hero-content {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  max-width: 320px;
+}
+
+.auth-hero-kicker {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(248, 250, 252, 0.16);
+  backdrop-filter: blur(16px);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--text-primary, #f8fafc);
+}
+
+.auth-hero-text {
+  color: rgba(248, 250, 252, 0.82);
+  font-size: 0.95rem;
+  line-height: 1.6;
+}
+
+.auth-form-side {
+  background: #ffffff;
+  display: flex;
+  flex-direction: column;
+}
+
+.auth-form-inner {
+  width: 100%;
+  max-width: 420px;
+  margin: 0 auto;
+  padding: clamp(2rem, 5vw, 4.5rem);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.auth-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.auth-title {
+  margin: 0;
+  font-size: clamp(1.75rem, 2vw + 1rem, 2.25rem);
+  font-weight: 600;
+  color: var(--text-color-primary, #0f172a);
+}
+
+.auth-form .form-label {
+  font-weight: 600;
+  color: var(--text-color-primary, #0f172a);
+}
+
+.auth-form .form-control {
+  border-radius: 0.9rem;
+  padding: 0.85rem 1rem;
+  border-color: var(--border-subtle, rgba(148, 163, 184, 0.18));
+  box-shadow: none;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.auth-form .form-control:focus {
+  border-color: var(--color-primary, #2563eb);
+  box-shadow: var(--focus-ring, 0 0 0 0.2rem rgba(37, 99, 235, 0.35));
+}
+
+.auth-microcopy {
+  margin-top: 0.5rem;
+}
+
+.auth-meta-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-top: 0.75rem;
+  margin-bottom: 1.5rem;
+}
+
+.auth-remember {
+  margin: 0;
+}
+
+.auth-remember .form-check-label {
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: var(--text-color-secondary, #334155);
+}
+
+.auth-remember .form-check-input:focus {
+  border-color: var(--color-primary, #2563eb);
+  box-shadow: var(--focus-ring, 0 0 0 0.2rem rgba(37, 99, 235, 0.35));
+}
+
+.auth-help {
+  display: inline-flex;
+  gap: 0.25rem;
+  align-items: center;
+  color: var(--text-color-muted, #64748b);
+  text-align: right;
+}
+
+.auth-help a {
+  color: var(--color-primary, #2563eb);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.auth-help a:hover,
+.auth-help a:focus {
+  color: var(--color-primary-hover, #1d4ed8);
+  text-decoration: underline;
+}
+
+.auth-form button[type='submit'] {
+  padding: 0.95rem 1rem;
+  font-size: 1rem;
+  font-weight: 600;
+  border-radius: 0.9rem;
+  box-shadow: 0 16px 32px rgba(37, 99, 235, 0.24);
+}
+
+.auth-form button[type='submit']:hover,
+.auth-form button[type='submit']:focus {
+  box-shadow: 0 20px 40px rgba(37, 99, 235, 0.28);
+}
+
+.auth-alert {
+  border-radius: 0.9rem;
+  margin: 0;
+}
+
+.auth-footer {
+  margin-top: auto;
+  padding: clamp(1.5rem, 3vw, 2rem);
+  background: var(--color-neutral-100, #f1f5f9);
+  border-top: 1px solid var(--border-subtle, rgba(148, 163, 184, 0.18));
+  text-align: center;
+}
+
+.auth-footer a {
+  color: var(--color-primary, #2563eb);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.auth-footer a:hover,
+.auth-footer a:focus {
+  color: var(--color-primary-hover, #1d4ed8);
+  text-decoration: underline;
+}
+
+@media (max-width: 992px) {
+  .auth-card {
+    grid-template-columns: 1fr;
+  }
+
+  .auth-hero {
+    min-height: 280px;
+    align-items: flex-end;
+  }
+}
+
+@media (max-width: 768px) {
+  .auth-meta-row {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .auth-help {
+    text-align: left;
+  }
+}
+
+@media (max-width: 640px) {
+  .auth-layout {
+    padding: clamp(1rem, 6vw, 1.5rem);
+  }
+
+  .auth-form-inner {
+    padding: clamp(1.75rem, 6vw, 2.5rem);
+  }
+
+  .auth-footer {
+    padding: clamp(1.25rem, 5vw, 1.75rem);
+  }
+}

--- a/frontend/src/pages/LoginPage.js
+++ b/frontend/src/pages/LoginPage.js
@@ -1,59 +1,111 @@
-
-
 import React, { useState } from 'react';
 import axios from 'axios';
 import { useNavigate, Link } from 'react-router-dom';
-import { Container, Form, Button, Card, Alert } from 'react-bootstrap';
+import { Form, Alert } from 'react-bootstrap';
+import './LoginPage.css';
 
 // 1. Centralize the API URL
 const API_URL = 'http://127.0.0.1:8000/api';
 
 function LoginPage() {
-    const [username, setUsername] = useState('');
-    const [password, setPassword] = useState('');
-    const [error, setError] = useState('');
-    const navigate = useNavigate();
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const navigate = useNavigate();
 
-    const handleSubmit = async (e) => {
-        e.preventDefault();
-        setError('');
-        try {
-            // 2. Use the API_URL constant for the request
-            const response = await axios.post(`${API_URL}/token/`, { username, password });
-            localStorage.setItem('accessToken', response.data.access);
-            localStorage.setItem('refreshToken', response.data.refresh);
-            localStorage.setItem('username', username);
-            navigate('/dashboard');
-        } catch (err) {
-            setError('Login failed. Please check your username and password.');
-            console.error('Login failed:', err);
-        }
-    };
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError('');
+    try {
+      // 2. Use the API_URL constant for the request
+      const response = await axios.post(`${API_URL}/token/`, { username, password });
+      localStorage.setItem('accessToken', response.data.access);
+      localStorage.setItem('refreshToken', response.data.refresh);
+      localStorage.setItem('username', username);
+      navigate('/dashboard');
+    } catch (err) {
+      setError('Login failed. Please check your username and password.');
+      console.error('Login failed:', err);
+    }
+  };
 
-    return (
-        <Container className="d-flex align-items-center justify-content-center" style={{ minHeight: '100vh' }}>
-            <Card style={{ width: '100%', maxWidth: '400px' }}>
-                <Card.Body>
-                    <h2 className="text-center mb-4">Log In</h2>
-                    {error && <Alert variant="danger">{error}</Alert>}
-                    <Form onSubmit={handleSubmit}>
-                        <Form.Group id="username" className="mb-3">
-                            <Form.Label>Username</Form.Label>
-                            <Form.Control type="text" value={username} onChange={(e) => setUsername(e.target.value)} required />
-                        </Form.Group>
-                        <Form.Group id="password"  className="mb-3">
-                            <Form.Label>Password</Form.Label>
-                            <Form.Control type="password" value={password} onChange={(e) => setPassword(e.target.value)} required />
-                        </Form.Group>
-                        <Button className="w-100" type="submit">Log In</Button>
-                    </Form>
-                </Card.Body>
-                <Card.Footer className="text-muted text-center">
-                    Need an account? <Link to="/register">Register</Link>
-                </Card.Footer>
-            </Card>
-        </Container>
-    );
+  return (
+    <main className="auth-layout">
+      <section className="auth-card">
+        <aside className="auth-hero" aria-hidden="true">
+          <div className="auth-hero-content">
+            <span className="auth-hero-kicker">Accounting OS</span>
+            <h1>Run your finances with clarity.</h1>
+            <p className="auth-hero-text">
+              Streamline invoicing, reconcile accounts, and monitor cash flow with real-time insights designed for modern teams.
+            </p>
+          </div>
+        </aside>
+        <div className="auth-form-side">
+          <div className="auth-form-inner">
+            <header className="auth-header">
+              <h2 className="auth-title">Sign in to your workspace</h2>
+              <p className="text-muted mb-0">
+                Welcome back! Please enter your details to continue.
+              </p>
+            </header>
+            {error && (
+              <Alert variant="danger" className="auth-alert">
+                {error}
+              </Alert>
+            )}
+            <Form onSubmit={handleSubmit} className="auth-form">
+              <Form.Group controlId="username" className="mb-3">
+                <Form.Label>Username</Form.Label>
+                <Form.Control
+                  type="text"
+                  value={username}
+                  onChange={(e) => setUsername(e.target.value)}
+                  placeholder="Enter your username"
+                  autoComplete="username"
+                  required
+                />
+              </Form.Group>
+              <Form.Group controlId="password" className="mb-2">
+                <Form.Label>Password</Form.Label>
+                <Form.Control
+                  type="password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  placeholder="••••••••"
+                  autoComplete="current-password"
+                  required
+                />
+                <p className="text-microcopy auth-microcopy">
+                  Use at least 8 characters, including a number and a symbol.
+                </p>
+              </Form.Group>
+              <div className="auth-meta-row">
+                <Form.Check
+                  type="checkbox"
+                  id="rememberMe"
+                  label="Remember me"
+                  className="auth-remember"
+                />
+                <span className="text-microcopy auth-help">
+                  Trouble signing in?
+                  <a href="mailto:support@example.com">Contact support</a>
+                </span>
+              </div>
+              <button type="submit" className="btn btn-primary w-100">
+                Log In
+              </button>
+            </Form>
+          </div>
+          <footer className="auth-footer">
+            <span className="text-microcopy">
+              New to the platform? <Link to="/register">Create an account</Link>
+            </span>
+          </footer>
+        </div>
+      </section>
+    </main>
+  );
 }
 
 export default LoginPage;


### PR DESCRIPTION
## Summary
- add a responsive split login layout with a gradient hero and themed card styling
- refresh the login form markup to use semantic containers, theme button classes, and microcopy for guidance

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68ce4fac7d488323868c280de566e91b