### PR TITLE
feat: apply shared data table styling across pages

### DIFF
--- a/frontend/src/pages/BankAccountDetailPage.js
+++ b/frontend/src/pages/BankAccountDetailPage.js
@@ -5,6 +5,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { Alert, Badge, Button, Card, Col, Form, Modal, Row, Spinner, Table } from 'react-bootstrap';
 import axiosInstance from '../utils/axiosInstance';
 import { ACCOUNT_CATEGORY_MAP, getCategoryConfig } from '../utils/bankAccountCategories';
+import '../styles/datatable.css';
 
 const TRANSACTION_TYPE_META = {
     deposit: { label: 'Deposit', variant: 'success' },
@@ -278,7 +279,8 @@ function BankAccountDetailPage() {
                     <h5 className="mb-0">Manual Transactions</h5>
                 </Card.Header>
                 <Card.Body className="p-0">
-                    <Table responsive hover className="mb-0">
+                    <div className="data-table-container">
+                        <Table responsive className="data-table">
                         <thead>
                             <tr>
                                 <th>Date</th>
@@ -292,7 +294,7 @@ function BankAccountDetailPage() {
                         <tbody>
                             {transactions.length === 0 ? (
                                 <tr>
-                                    <td colSpan={6} className="text-center text-muted py-4">
+                                    <td colSpan={6} className="data-table-empty">
                                         No manual transactions recorded yet.
                                     </td>
                                 </tr>
@@ -319,7 +321,8 @@ function BankAccountDetailPage() {
                                 })
                             )}
                         </tbody>
-                    </Table>
+                        </Table>
+                    </div>
                 </Card.Body>
             </Card>
 

--- a/frontend/src/pages/CustomerBalanceReportPage.js
+++ b/frontend/src/pages/CustomerBalanceReportPage.js
@@ -14,6 +14,7 @@ import {
 } from 'react-bootstrap';
 import { formatCurrency } from '../utils/format';
 import { downloadBlobResponse } from '../utils/download';
+import '../styles/datatable.css';
 
 function CustomerBalanceReportPage() {
     const [reportData, setReportData] = useState([]);
@@ -204,20 +205,21 @@ function CustomerBalanceReportPage() {
                                 </Card>
                             </Col>
                         </Row>
-                        <Table striped bordered hover responsive>
-                            <thead>
-                                <tr>
-                                    <th>Name</th>
-                                    <th>Contact</th>
-                                    <th>Currency</th>
-                                    <th className="text-end">Balance</th>
-                                    <th>Status</th>
-                                </tr>
-                            </thead>
-                            <tbody>
+                        <div className="data-table-container">
+                            <Table responsive className="data-table">
+                                <thead>
+                                    <tr>
+                                        <th>Name</th>
+                                        <th>Contact</th>
+                                        <th>Currency</th>
+                                        <th className="text-end">Balance</th>
+                                        <th>Status</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
                                 {reportData.length === 0 ? (
                                     <tr>
-                                        <td colSpan="5" className="text-center py-4 text-muted">
+                                        <td colSpan="5" className="data-table-empty">
                                             No customer balances to display.
                                         </td>
                                     </tr>
@@ -249,8 +251,9 @@ function CustomerBalanceReportPage() {
                                         );
                                     })
                                 )}
-                            </tbody>
-                        </Table>
+                                </tbody>
+                            </Table>
+                        </div>
                     </>
                 )}
             </Card.Body>

--- a/frontend/src/pages/CustomerDetailPage.js
+++ b/frontend/src/pages/CustomerDetailPage.js
@@ -8,6 +8,7 @@ import { PersonCircle, Cash, Tag, Hammer, BarChart, PencilSquare, Trash } from '
 import './CustomerDetailPage.css';
 import CustomerPaymentModal from '../components/CustomerPaymentModal';
 import ActionMenu from '../components/ActionMenu';
+import '../styles/datatable.css';
 
 const API_BASE_URL = 'http://127.0.0.1:8000';
 
@@ -228,7 +229,7 @@ function CustomerDetailPage() {
                                                         ]}
                                                     />
                                                 </div>
-                                                <Table striped bordered hover size="sm">
+                                                <Table size="sm" className="data-table data-table--compact data-table--subtle">
                                                     <thead>
                                                         <tr>
                                                             <th>Product</th>
@@ -300,7 +301,7 @@ function CustomerDetailPage() {
                                                         ]}
                                                     />
                                                 </div>
-                                                <Table borderless size="sm" className="mb-0">
+                                                <Table size="sm" className="data-table data-table--compact data-table--subtle mb-0">
                                                     <tbody>
                                                         <tr>
                                                             <td className="fw-bold">Account</td>
@@ -338,7 +339,7 @@ function CustomerDetailPage() {
                                                 </div>
                                             </Accordion.Header>
                                             <Accordion.Body>
-                                                <Table striped bordered hover size="sm">
+                                                <Table size="sm" className="data-table data-table--compact data-table--subtle">
                                                     <thead>
                                                         <tr>
                                                             <th>Product</th>

--- a/frontend/src/pages/CustomerListPage.js
+++ b/frontend/src/pages/CustomerListPage.js
@@ -5,6 +5,7 @@ import { useNavigate } from 'react-router-dom';
 import axiosInstance from '../utils/axiosInstance';
 import { Table, Button, Form, InputGroup, Row, Col, Spinner, Alert } from 'react-bootstrap';
 import { Plus, Upload, Wrench } from 'react-bootstrap-icons';
+import '../styles/datatable.css';
 
 function CustomerListPage() {
     const [customers, setCustomers] = useState([]);
@@ -64,7 +65,7 @@ function CustomerListPage() {
         <>
             {error && <Alert variant="danger">{error}</Alert>}
 
-            <Row className="mb-3 align-items-center">
+            <Row className="data-table-toolbar align-items-center">
                 <Col md={6}>
                     <div className="d-flex">
                         <Button variant="primary" className="me-2" onClick={() => navigate('/customers/new')}>
@@ -91,25 +92,29 @@ function CustomerListPage() {
             </Row>
 
             <h2 className="mb-3">Customers</h2>
-            <div className="table-container border rounded">
-                <Table striped hover responsive className="m-0">
-                    <thead className="table-dark">
+            <div className="data-table-container">
+                <Table responsive className="data-table">
+                    <thead>
                         <tr>
-                            <th style={{ padding: '1rem' }}>Name / Title</th>
-                            <th style={{ padding: '1rem' }}>Balance</th>
-                            <th style={{ padding: '1rem' }}>Check/Note Balance</th>
+                            <th>Name / Title</th>
+                            <th>Balance</th>
+                            <th>Check/Note Balance</th>
                         </tr>
                     </thead>
                     <tbody>
                         {loading ? (
                             <tr>
-                                <td colSpan="3" className="text-center p-5">
+                                <td colSpan="3" className="data-table-status">
                                     <Spinner animation="border" />
                                 </td>
                             </tr>
                         ) : customers.length > 0 ? (
                             customers.map((customer) => (
-                                <tr key={customer.id} onClick={() => navigate(`/customers/${customer.id}`)} style={{ cursor: 'pointer' }}>
+                                <tr
+                                    key={customer.id}
+                                    onClick={() => navigate(`/customers/${customer.id}`)}
+                                    className="data-table-row--link"
+                                >
                                     <td>{customer.name}</td>
                                     <td>{formatBalance(customer.balance, customer.currency)}</td>
                                     <td>{formatCurrency(0, customer.currency)}</td>
@@ -117,7 +122,7 @@ function CustomerListPage() {
                             ))
                         ) : (
                             <tr>
-                                <td colSpan="3" className="text-center p-5">
+                                <td colSpan="3" className="data-table-empty">
                                     {searchTerm ? `No customers found for "${searchTerm}".` : 'No customers found. Click "Add New Customer" to get started.'}
                                 </td>
                             </tr>

--- a/frontend/src/pages/EditSalePage.js
+++ b/frontend/src/pages/EditSalePage.js
@@ -6,6 +6,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { Form, Button, Card, Row, Col, Table, Alert, Spinner } from 'react-bootstrap';
 import { FaTrash } from 'react-icons/fa';
 import { formatCurrency } from '../utils/format';
+import '../styles/datatable.css';
 
 function EditSalePage() {
     const { id } = useParams();
@@ -116,7 +117,8 @@ function EditSalePage() {
                         </Form.Group>
                     </Row>
                       <h5>Sale Items</h5>
-                      <Table bordered hover responsive>
+                      <div className="data-table-container">
+                        <Table responsive className="data-table data-table--compact">
                         <thead>
                             <tr>
                                 <th>Product</th>
@@ -150,7 +152,8 @@ function EditSalePage() {
                                 </tr>
                             ))}
                         </tbody>
-                    </Table>
+                        </Table>
+                      </div>
                     <Button variant="secondary" onClick={handleAddItem} className="mb-3">+ Add Item</Button>
                     <div className="text-end">
                         <h3>Total: {formatCurrency(calculateTotal())}</h3>

--- a/frontend/src/pages/ExpenseListPage.js
+++ b/frontend/src/pages/ExpenseListPage.js
@@ -7,6 +7,7 @@ import { FaTrash, FaEdit } from 'react-icons/fa';
 import ActionMenu from '../components/ActionMenu';
 import { formatCurrency } from '../utils/format';
 import { getBaseCurrency, loadBaseCurrency } from '../config/currency';
+import '../styles/datatable.css';
 
 // This is the new, self-contained component for managing categories
 const CategoryManagerModal = ({ show, handleClose, categories, onUpdate }) => {
@@ -206,46 +207,54 @@ function ExpenseListPage() {
                     </div>
                 </Card.Header>
                 <Card.Body>
-                    <Table striped bordered hover responsive>
-                        <thead>
-                            <tr>
-                                <th>Date</th>
-                                <th>Category</th>
-                                <th>Account</th>
-                                <th>Description</th>
-                                <th>Amount</th>
-                                <th>Actions</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {expenses.map((expense) => (
-                                <tr key={expense.id}>
-                                    <td>{expense.expense_date}</td>
-                                    <td>{expense.category_name || 'Uncategorized'}</td>
-                                    <td>{expense.account_name || 'N/A'}</td>
-                                    <td>{expense.description}</td>
-                                    <td>{formatCurrency(expense.amount, expense.account_currency || baseCurrency)}</td>
-                                    <td className="text-nowrap">
-                                        <ActionMenu
-                                            actions={[
-                                                {
-                                                    label: 'Edit Expense',
-                                                    icon: <FaEdit />,
-                                                    onClick: () => handleShowModal(expense),
-                                                },
-                                                {
-                                                    label: 'Delete Expense',
-                                                    icon: <FaTrash />,
-                                                    variant: 'text-danger',
-                                                    onClick: () => handleDelete(expense.id),
-                                                },
-                                            ]}
-                                        />
-                                    </td>
+                    <div className="data-table-container">
+                        <Table responsive className="data-table">
+                            <thead>
+                                <tr>
+                                    <th>Date</th>
+                                    <th>Category</th>
+                                    <th>Account</th>
+                                    <th>Description</th>
+                                    <th>Amount</th>
+                                    <th>Actions</th>
                                 </tr>
-                            ))}
-                        </tbody>
-                    </Table>
+                            </thead>
+                            <tbody>
+                            {expenses.length > 0 ? (
+                                expenses.map((expense) => (
+                                    <tr key={expense.id}>
+                                        <td>{expense.expense_date}</td>
+                                        <td>{expense.category_name || 'Uncategorized'}</td>
+                                        <td>{expense.account_name || 'N/A'}</td>
+                                        <td>{expense.description}</td>
+                                        <td>{formatCurrency(expense.amount, expense.account_currency || baseCurrency)}</td>
+                                        <td className="text-nowrap">
+                                            <ActionMenu
+                                                actions={[
+                                                    {
+                                                        label: 'Edit Expense',
+                                                        icon: <FaEdit />,
+                                                        onClick: () => handleShowModal(expense),
+                                                    },
+                                                    {
+                                                        label: 'Delete Expense',
+                                                        icon: <FaTrash />,
+                                                        variant: 'text-danger',
+                                                        onClick: () => handleDelete(expense.id),
+                                                    },
+                                                ]}
+                                            />
+                                        </td>
+                                    </tr>
+                                ))
+                            ) : (
+                                <tr>
+                                    <td colSpan="6" className="data-table-empty">No expenses have been recorded yet.</td>
+                                </tr>
+                            )}
+                            </tbody>
+                        </Table>
+                    </div>
                 </Card.Body>
             </Card>
 

--- a/frontend/src/pages/OfferDetailPage.js
+++ b/frontend/src/pages/OfferDetailPage.js
@@ -3,6 +3,7 @@ import { useParams, useNavigate } from 'react-router-dom';
 import axiosInstance from '../utils/axiosInstance';
 import { Card, Button, Spinner, Alert, Row, Col, Table } from 'react-bootstrap';
 import { formatCurrency } from '../utils/format';
+import '../styles/datatable.css';
 
 function OfferDetailPage() {
     const { id } = useParams();
@@ -74,24 +75,30 @@ function OfferDetailPage() {
                         </Row>
 
                         <h5>Items</h5>
-                        <Table striped bordered hover responsive>
-                            <thead>
-                                <tr>
-                                    <th>#</th><th>Product</th><th>Quantity</th><th>Unit Price</th><th>Line Total</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                {offer.items.map((item, index) => (
-                                    <tr key={item.id}>
-                                        <td>{index + 1}</td>
-                                        <td>{item.product_name}</td>
-                                        <td>{item.quantity}</td>
-                                        <td>{formatCurrency(item.unit_price)}</td>
-                                        <td>{formatCurrency(item.quantity * item.unit_price)}</td>
+                        <div className="data-table-container">
+                            <Table responsive className="data-table">
+                                <thead>
+                                    <tr>
+                                        <th>#</th>
+                                        <th>Product</th>
+                                        <th>Quantity</th>
+                                        <th>Unit Price</th>
+                                        <th>Line Total</th>
                                     </tr>
-                                ))}
-                            </tbody>
-                        </Table>
+                                </thead>
+                                <tbody>
+                                    {offer.items.map((item, index) => (
+                                        <tr key={item.id}>
+                                            <td>{index + 1}</td>
+                                            <td>{item.product_name}</td>
+                                            <td>{item.quantity}</td>
+                                            <td>{formatCurrency(item.unit_price)}</td>
+                                            <td>{formatCurrency(item.quantity * item.unit_price)}</td>
+                                        </tr>
+                                    ))}
+                                </tbody>
+                            </Table>
+                        </div>
 
                         <hr />
 

--- a/frontend/src/pages/OfferListPage.js
+++ b/frontend/src/pages/OfferListPage.js
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import axiosInstance from '../utils/axiosInstance';
 import { Card, Button, Table, Alert, Spinner } from 'react-bootstrap';
 import { formatCurrency } from '../utils/format';
+import '../styles/datatable.css';
 
 function OfferListPage() {
     const [offers, setOffers] = useState([]);
@@ -41,42 +42,44 @@ function OfferListPage() {
             </Card.Header>
             <Card.Body>
                 {error && <Alert variant="danger">{error}</Alert>}
-                <Table striped bordered hover responsive>
-                    <thead>
-                        <tr>
-                            <th>#</th>
-                            <th>Offer No.</th>
-                            <th>Customer</th>
-                            <th>Date</th>
-                            <th>Status</th>
-                            <th>Total Amount</th>
-                            <th>Actions</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {offers.length > 0 ? (
-                            offers.map((offer, index) => (
-                                <tr key={offer.id}>
-                                    <td>{index + 1}</td>
-                                    <td>{`OFFER-${offer.id}`}</td>
-                                    <td>{offer.customer_name}</td>
-                                    <td>{new Date(offer.offer_date).toLocaleDateString()}</td>
-                                    <td>{offer.status}</td>
-                                    <td>{formatCurrency(offer.total_amount)}</td>
-                                    <td>
-                                        <Button as={Link} to={`/offers/${offer.id}`} variant="info" size="sm">
-                                        View
-                                    </Button>
-                                    </td>
-                                </tr>
-                            ))
-                        ) : (
+                <div className="data-table-container">
+                    <Table responsive className="data-table">
+                        <thead>
                             <tr>
-                                <td colSpan="7" className="text-center">No offers found.</td>
+                                <th>#</th>
+                                <th>Offer No.</th>
+                                <th>Customer</th>
+                                <th>Date</th>
+                                <th>Status</th>
+                                <th>Total Amount</th>
+                                <th>Actions</th>
                             </tr>
-                        )}
-                    </tbody>
-                </Table>
+                        </thead>
+                        <tbody>
+                            {offers.length > 0 ? (
+                                offers.map((offer, index) => (
+                                    <tr key={offer.id}>
+                                        <td>{index + 1}</td>
+                                        <td>{`OFFER-${offer.id}`}</td>
+                                        <td>{offer.customer_name}</td>
+                                        <td>{new Date(offer.offer_date).toLocaleDateString()}</td>
+                                        <td>{offer.status}</td>
+                                        <td>{formatCurrency(offer.total_amount)}</td>
+                                        <td>
+                                            <Button as={Link} to={`/offers/${offer.id}`} variant="info" size="sm">
+                                                View
+                                            </Button>
+                                        </td>
+                                    </tr>
+                                ))
+                            ) : (
+                                <tr>
+                                    <td colSpan="7" className="data-table-empty">No offers found.</td>
+                                </tr>
+                            )}
+                        </tbody>
+                    </Table>
+                </div>
             </Card.Body>
         </Card>
     );

--- a/frontend/src/pages/ProductListPage.js
+++ b/frontend/src/pages/ProductListPage.js
@@ -5,6 +5,7 @@ import { useNavigate } from 'react-router-dom';
 import axiosInstance from '../utils/axiosInstance';
 import { Table, Button, Card, Spinner, Image, Modal } from 'react-bootstrap';
 import { Plus } from 'react-bootstrap-icons';
+import '../styles/datatable.css';
 
 const API_BASE_URL = 'http://127.0.0.1:8000';
 
@@ -53,55 +54,63 @@ function ProductListPage() {
                 </Button>
             </Card.Header>
             <Card.Body>
-                <Table striped bordered hover responsive>
-                    <thead className="table-dark">
-                        <tr>
-                            <th>Image</th>
-                            <th>SKU</th>
-                            <th>Name</th>
-                            <th>Stock Quantity</th>
-                            <th>Sale Price</th>
-                            <th>Actions</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {loading ? (
-                            <tr><td colSpan="6" className="text-center"><Spinner animation="border" /></td></tr>
-                        ) : products.length > 0 ? (
-                            products.map(product => (
-                                <tr key={product.id}>
-                                    <td>
-                                        {product.image && (
-                                            <Image
-                                                src={
-                                                    product.image.startsWith('http')
-                                                        ? product.image
-                                                        : `${API_BASE_URL}${product.image}`
-                                                }
-                                                rounded
-                                                width={50}
-                                                height={50}
-                                                style={{ cursor: 'pointer' }}
-                                                onClick={() => handleImageClick(product.image)}
-                                            />
-                                        )}
-                                    </td>
-                                    <td>{product.sku || 'N/A'}</td>
-                                    <td>{product.name}</td>
-                                    <td>{product.stock_quantity}</td>
-                                    <td>{formatCurrency(product.sale_price)}</td>
-                                    <td>
-                                        <Button variant="info" size="sm" onClick={() => navigate(`/inventory/edit/${product.id}`)}>
-                                            Edit
-                                        </Button>
+                <div className="data-table-container">
+                    <Table responsive className="data-table">
+                        <thead>
+                            <tr>
+                                <th>Image</th>
+                                <th>SKU</th>
+                                <th>Name</th>
+                                <th>Stock Quantity</th>
+                                <th>Sale Price</th>
+                                <th>Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {loading ? (
+                                <tr>
+                                    <td colSpan="6" className="data-table-status">
+                                        <Spinner animation="border" />
                                     </td>
                                 </tr>
-                            ))
-                        ) : (
-                            <tr><td colSpan="6" className="text-center">No products found.</td></tr>
-                        )}
-                    </tbody>
-                </Table>
+                            ) : products.length > 0 ? (
+                                products.map(product => (
+                                    <tr key={product.id}>
+                                        <td>
+                                            {product.image && (
+                                                <Image
+                                                    src={
+                                                        product.image.startsWith('http')
+                                                            ? product.image
+                                                            : `${API_BASE_URL}${product.image}`
+                                                    }
+                                                    rounded
+                                                    width={50}
+                                                    height={50}
+                                                    style={{ cursor: 'pointer' }}
+                                                    onClick={() => handleImageClick(product.image)}
+                                                />
+                                            )}
+                                        </td>
+                                        <td>{product.sku || 'N/A'}</td>
+                                        <td>{product.name}</td>
+                                        <td>{product.stock_quantity}</td>
+                                        <td>{formatCurrency(product.sale_price)}</td>
+                                        <td>
+                                            <Button variant="info" size="sm" onClick={() => navigate(`/inventory/edit/${product.id}`)}>
+                                                Edit
+                                            </Button>
+                                        </td>
+                                    </tr>
+                                ))
+                            ) : (
+                                <tr>
+                                    <td colSpan="6" className="data-table-empty">No products found.</td>
+                                </tr>
+                            )}
+                        </tbody>
+                    </Table>
+                </div>
             </Card.Body>
             <Modal show={showImageModal} onHide={handleCloseModal} centered>
                 <Modal.Body className="text-center">

--- a/frontend/src/pages/ProfitLossPage.js
+++ b/frontend/src/pages/ProfitLossPage.js
@@ -5,6 +5,7 @@ import axiosInstance from '../utils/axiosInstance';
 import { Card, Button, Form, Row, Col, Spinner, Alert, Table } from 'react-bootstrap';
 import { formatCurrency } from '../utils/format';
 import { downloadBlobResponse } from '../utils/download';
+import '../styles/datatable.css';
 
 // Helper to get the first day of the current month
 const getFirstDayOfMonth = () => {
@@ -147,11 +148,11 @@ function ProfitLossPage() {
                                 )}
                             </Button>
                         </div>
-                        <div className="mt-4">
+                        <div className="mt-4 data-table-container">
                             <h5 className="text-center">Report for {reportData.start_date} to {reportData.end_date}</h5>
                             <hr />
 
-                            <Table striped bordered hover responsive>
+                            <Table responsive className="data-table">
                                 <tbody>
                                     <tr className="table-success">
                                         <td><strong>Total Revenue (Sales)</strong></td>

--- a/frontend/src/pages/PurchaseDetailPage.js
+++ b/frontend/src/pages/PurchaseDetailPage.js
@@ -5,6 +5,7 @@ import { useParams, useNavigate, Link } from 'react-router-dom';
 import axiosInstance from '../utils/axiosInstance';
 import { Card, Button, Spinner, Alert, Row, Col, Table } from 'react-bootstrap';
 import { formatCurrency } from '../utils/format';
+import '../styles/datatable.css';
 
 function PurchaseDetailPage() {
     const { id } = useParams();
@@ -57,19 +58,21 @@ function PurchaseDetailPage() {
                             <Col><strong>Account:</strong> {purchase.account_name || 'N/A'}</Col>
                         </Row>
                           <h5>Items Purchased</h5>
-                          <Table striped bordered responsive>
-                            <thead><tr><th>Product</th><th>Quantity</th><th>Unit Price</th><th>Line Total</th></tr></thead>
-                            <tbody>
-                                {purchase.items.map(item => (
-                                    <tr key={item.id}>
-                                        <td>{item.product_name}</td>
-                                        <td>{item.quantity}</td>
-                                        <td>{formatCurrency(item.unit_price, purchase.original_currency || 'USD')}</td>
-                                        <td>{formatCurrency(item.line_total, purchase.original_currency || 'USD')}</td>
-                                    </tr>
-                                ))}
-                            </tbody>
-                        </Table>
+                          <div className="data-table-container">
+                            <Table responsive className="data-table data-table--compact">
+                                <thead><tr><th>Product</th><th>Quantity</th><th>Unit Price</th><th>Line Total</th></tr></thead>
+                                <tbody>
+                                    {purchase.items.map(item => (
+                                        <tr key={item.id}>
+                                            <td>{item.product_name}</td>
+                                            <td>{item.quantity}</td>
+                                            <td>{formatCurrency(item.unit_price, purchase.original_currency || 'USD')}</td>
+                                            <td>{formatCurrency(item.line_total, purchase.original_currency || 'USD')}</td>
+                                        </tr>
+                                    ))}
+                                </tbody>
+                            </Table>
+                          </div>
                         <h4 className="text-end mt-3">Total: {formatCurrency(purchase.total_amount, purchase.original_currency || 'USD')}</h4>
                     </Card.Body>
                     <Card.Footer className="text-end">

--- a/frontend/src/pages/PurchaseFormPage.js
+++ b/frontend/src/pages/PurchaseFormPage.js
@@ -5,6 +5,7 @@ import { useParams, useNavigate } from 'react-router-dom';
 import axiosInstance from '../utils/axiosInstance';
 import { Container, Card, Form, Button, Row, Col, Table } from 'react-bootstrap';
 import { Trash } from 'react-bootstrap-icons';
+import '../styles/datatable.css';
 
 function PurchaseFormPage() {
     const { supplierId, customerId } = useParams();
@@ -93,34 +94,68 @@ function PurchaseFormPage() {
                             </Col>
                         </Row>
 
-                          <h5>Items</h5>
-                          <Table striped bordered hover responsive>
-                            <thead>
-                                <tr>
-                                    <th>Product</th>
-                                    <th>Quantity</th>
-                                    <th>Unit Price</th>
-                                    <th>Line Total</th>
-                                    <th>Actions</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                {lineItems.map((item, index) => (
-                                    <tr key={index}>
-                                        <td>
-                                            <Form.Select name="product_id" value={item.product_id} onChange={e => handleLineItemChange(index, e)}>
-                                                <option>Select Product</option>
-                                                {allProducts.map(p => <option key={p.id} value={p.id}>{p.name}</option>)}
-                                            </Form.Select>
-                                        </td>
-                                        <td><Form.Control type="number" name="quantity" value={item.quantity} onChange={e => handleLineItemChange(index, e)} /></td>
-                                        <td><Form.Control type="number" step="0.01" name="unit_price" value={item.unit_price} onChange={e => handleLineItemChange(index, e)} /></td>
-                                        <td>{new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(item.quantity * item.unit_price)}</td>
-                                        <td><Button variant="danger" onClick={() => handleRemoveItem(index)}><Trash /></Button></td>
+                        <h5>Items</h5>
+                        <div className="data-table-container">
+                            <Table responsive className="data-table data-table--compact">
+                                <thead>
+                                    <tr>
+                                        <th>Product</th>
+                                        <th>Quantity</th>
+                                        <th>Unit Price</th>
+                                        <th>Line Total</th>
+                                        <th>Actions</th>
                                     </tr>
-                                ))}
-                            </tbody>
-                        </Table>
+                                </thead>
+                                <tbody>
+                                    {lineItems.map((item, index) => (
+                                        <tr key={index}>
+                                            <td>
+                                                <Form.Select
+                                                    name="product_id"
+                                                    value={item.product_id}
+                                                    onChange={(e) => handleLineItemChange(index, e)}
+                                                >
+                                                    <option>Select Product</option>
+                                                    {allProducts.map((product) => (
+                                                        <option key={product.id} value={product.id}>
+                                                            {product.name}
+                                                        </option>
+                                                    ))}
+                                                </Form.Select>
+                                            </td>
+                                            <td>
+                                                <Form.Control
+                                                    type="number"
+                                                    name="quantity"
+                                                    value={item.quantity}
+                                                    onChange={(e) => handleLineItemChange(index, e)}
+                                                />
+                                            </td>
+                                            <td>
+                                                <Form.Control
+                                                    type="number"
+                                                    step="0.01"
+                                                    name="unit_price"
+                                                    value={item.unit_price}
+                                                    onChange={(e) => handleLineItemChange(index, e)}
+                                                />
+                                            </td>
+                                            <td>
+                                                {new Intl.NumberFormat('en-US', {
+                                                    style: 'currency',
+                                                    currency: 'USD',
+                                                }).format(item.quantity * item.unit_price)}
+                                            </td>
+                                            <td>
+                                                <Button variant="danger" onClick={() => handleRemoveItem(index)}>
+                                                    <Trash />
+                                                </Button>
+                                            </td>
+                                        </tr>
+                                    ))}
+                                </tbody>
+                            </Table>
+                        </div>
                         <Button variant="secondary" onClick={handleAddItem}>+ Add Item</Button>
 
                         <div className="d-flex justify-content-end mt-3">

--- a/frontend/src/pages/PurchaseListPage.js
+++ b/frontend/src/pages/PurchaseListPage.js
@@ -6,6 +6,7 @@ import { Link } from 'react-router-dom';
 import { Form, Button, Card, Row, Col, Table, Alert, Modal, Spinner } from 'react-bootstrap';
 import { formatCurrency } from '../utils/format';
 import { FaTrash } from 'react-icons/fa';
+import '../styles/datatable.css';
 
 const getTodayDate = () => {
     const today = new Date();
@@ -154,32 +155,44 @@ function PurchaseListPage() {
                 </Card.Header>
                 <Card.Body>
                     {error && !showModal && <Alert variant="danger">{error}</Alert>}
-                    <Table striped bordered hover responsive>
-                        <thead>
-                            <tr>
-                                <th>Date</th>
-                                <th>Supplier</th>
-                                <th>Bill #</th>
-                                <th>Account</th>
-                                <th>Total Amount</th>
-                                <th>Actions</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {purchases.map(purchase => (
-                                <tr key={purchase.id}>
-                                    <td>{purchase.purchase_date}</td>
-                                    <td>{purchase.supplier_name}</td>
-                                    <td>{purchase.bill_number || 'N/A'}</td>
-                                    <td>{purchase.account_name || 'N/A'}</td>
-                                    <td>{formatCurrency(purchase.total_amount, purchase.original_currency || 'USD')}</td>
-                                    <td>
-                                        <Button as={Link} to={`/purchases/${purchase.id}`} variant="info" size="sm">View</Button>
-                                    </td>
+                    <div className="data-table-container">
+                        <Table responsive className="data-table">
+                            <thead>
+                                <tr>
+                                    <th>Date</th>
+                                    <th>Supplier</th>
+                                    <th>Bill #</th>
+                                    <th>Account</th>
+                                    <th>Total Amount</th>
+                                    <th>Actions</th>
                                 </tr>
-                            ))}
-                        </tbody>
-                    </Table>
+                            </thead>
+                            <tbody>
+                                {purchases.length > 0 ? (
+                                    purchases.map((purchase) => (
+                                        <tr key={purchase.id}>
+                                            <td>{purchase.purchase_date}</td>
+                                            <td>{purchase.supplier_name}</td>
+                                            <td>{purchase.bill_number || 'N/A'}</td>
+                                            <td>{purchase.account_name || 'N/A'}</td>
+                                            <td>
+                                                {formatCurrency(purchase.total_amount, purchase.original_currency || 'USD')}
+                                            </td>
+                                            <td>
+                                                <Button as={Link} to={`/purchases/${purchase.id}`} variant="info" size="sm">
+                                                    View
+                                                </Button>
+                                            </td>
+                                        </tr>
+                                    ))
+                                ) : (
+                                    <tr>
+                                        <td colSpan="6" className="data-table-empty">No purchases recorded yet.</td>
+                                    </tr>
+                                )}
+                            </tbody>
+                        </Table>
+                    </div>
                 </Card.Body>
             </Card>
 

--- a/frontend/src/pages/SaleDetailPage.js
+++ b/frontend/src/pages/SaleDetailPage.js
@@ -6,6 +6,7 @@ import axiosInstance from '../utils/axiosInstance';
 import { Card, Button, Spinner, Alert, Row, Col, Table } from 'react-bootstrap';
 import AddPaymentModal from '../components/AddPaymentModal';
 import { getBaseCurrency, loadBaseCurrency } from '../config/currency';
+import '../styles/datatable.css';
 
 function SaleDetailPage() {
     const { id } = useParams();
@@ -135,62 +136,72 @@ const balanceDueBase = sale ? parseFloat(sale.converted_amount || sale.total_amo
 
                         {/* ... Items Sold Table (no changes here) ... */}
                         <h5>Items Sold</h5>
-                        <Table striped bordered hover responsive>
-                            <thead>
-                                <tr>
-                                    <th>#</th><th>Product</th><th>Quantity</th><th>Unit Price</th><th>Line Total</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                {sale.items.map((item, index) => (
-                                    <tr key={item.id}>
-                                        <td>{index + 1}</td>
-                                        <td>{item.product_name}</td>
-                                        <td>{item.quantity}</td>
-                                        <td>{formatCurrency(item.unit_price, sale.original_currency)}</td>
-                                        <td>{formatCurrency(item.quantity * item.unit_price, sale.original_currency)}</td>
+                        <div className="data-table-container">
+                            <Table responsive className="data-table">
+                                <thead>
+                                    <tr>
+                                        <th>#</th>
+                                        <th>Product</th>
+                                        <th>Quantity</th>
+                                        <th>Unit Price</th>
+                                        <th>Line Total</th>
                                     </tr>
-                                ))}
-                            </tbody>
-                        </Table>
+                                </thead>
+                                <tbody>
+                                    {sale.items.map((item, index) => (
+                                        <tr key={item.id}>
+                                            <td>{index + 1}</td>
+                                            <td>{item.product_name}</td>
+                                            <td>{item.quantity}</td>
+                                            <td>{formatCurrency(item.unit_price, sale.original_currency)}</td>
+                                            <td>{formatCurrency(item.quantity * item.unit_price, sale.original_currency)}</td>
+                                        </tr>
+                                    ))}
+                                </tbody>
+                            </Table>
+                        </div>
 
                         <hr />
 
                         {/* --- NEW PAYMENT HISTORY SECTION --- */}
                         <Row className="mt-4">
                             <Col md={8}>
-                                  <h5>Payment History</h5>
-                                  <Table bordered size="sm" responsive>
-                                    <thead>
-                                        <tr>
-                                            <th>Date</th>
-                                            <th>Amount</th>
-                                            <th>Method</th>
-                                            <th>Notes</th>
-                                        </tr>
-                                    </thead>
-                                    <tbody>
-                                        {payments.length > 0 ? payments.map(p => (
-                                            <tr key={p.id}>
-                                                <td>{new Date(p.payment_date).toLocaleDateString()}</td>
-                                                <td>
-                                                    {formatCurrency(p.original_amount, p.original_currency)}
-                                                    {p.original_currency !== baseCurrency && (
-                                                        <div className="text-muted">
-                                                            {formatCurrency((p.converted_amount ?? p.amount) * parseFloat(sale.exchange_rate || 1), baseCurrency)}
-                                                        </div>
-                                                    )}
-                                                </td>
-                                                <td>{p.method}</td>
-                                                <td>{p.notes || 'N/A'}</td>
-                                            </tr>
-                                        )) : (
+                                <h5>Payment History</h5>
+                                <div className="data-table-container">
+                                    <Table size="sm" responsive className="data-table data-table--compact">
+                                        <thead>
                                             <tr>
-                                                <td colSpan="4" className="text-center">No payments recorded.</td>
+                                                <th>Date</th>
+                                                <th>Amount</th>
+                                                <th>Method</th>
+                                                <th>Notes</th>
                                             </tr>
-                                        )}
-                                    </tbody>
-                                </Table>
+                                        </thead>
+                                        <tbody>
+                                            {payments.length > 0 ? (
+                                                payments.map((p) => (
+                                                    <tr key={p.id}>
+                                                        <td>{new Date(p.payment_date).toLocaleDateString()}</td>
+                                                        <td>
+                                                            {formatCurrency(p.original_amount, p.original_currency)}
+                                                            {p.original_currency !== baseCurrency && (
+                                                                <div className="text-muted">
+                                                                    {formatCurrency((p.converted_amount ?? p.amount) * parseFloat(sale.exchange_rate || 1), baseCurrency)}
+                                                                </div>
+                                                            )}
+                                                        </td>
+                                                        <td>{p.method}</td>
+                                                        <td>{p.notes || 'N/A'}</td>
+                                                    </tr>
+                                                ))
+                                            ) : (
+                                                <tr>
+                                                    <td colSpan="4" className="data-table-empty">No payments recorded.</td>
+                                                </tr>
+                                            )}
+                                        </tbody>
+                                    </Table>
+                                </div>
                                 <Button
                                     variant="success"
                                     size="sm"

--- a/frontend/src/pages/SaleFormPage.js
+++ b/frontend/src/pages/SaleFormPage.js
@@ -5,6 +5,7 @@ import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import axiosInstance from '../utils/axiosInstance';
 import { Container, Card, Form, Button, Row, Col, Table, InputGroup } from 'react-bootstrap';
 import { Trash } from 'react-bootstrap-icons';
+import '../styles/datatable.css';
 
 function SaleFormPage() {
     const { customerId, supplierId } = useParams();
@@ -108,34 +109,68 @@ function SaleFormPage() {
                             </Col>
                         </Row>
 
-                          <h5>Items</h5>
-                          <Table striped bordered hover responsive>
-                            <thead>
-                                <tr>
-                                    <th>Product</th>
-                                    <th>Quantity</th>
-                                    <th>Unit Price</th>
-                                    <th>Line Total</th>
-                                    <th>Actions</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                {lineItems.map((item, index) => (
-                                    <tr key={index}>
-                                        <td>
-                                            <Form.Select name="product_id" value={item.product_id} onChange={e => handleLineItemChange(index, e)}>
-                                                <option>Select Product</option>
-                                                {allProducts.map(p => <option key={p.id} value={p.id}>{p.name}</option>)}
-                                            </Form.Select>
-                                        </td>
-                                        <td><Form.Control type="number" name="quantity" value={item.quantity} onChange={e => handleLineItemChange(index, e)} /></td>
-                                        <td><Form.Control type="number" step="0.01" name="unit_price" value={item.unit_price} onChange={e => handleLineItemChange(index, e)} /></td>
-                                        <td>{new Intl.NumberFormat('en-US', { style: 'currency', currency: customer.currency }).format(item.quantity * item.unit_price)}</td>
-                                        <td><Button variant="danger" onClick={() => handleRemoveItem(index)}><Trash /></Button></td>
+                        <h5>Items</h5>
+                        <div className="data-table-container">
+                            <Table responsive className="data-table data-table--compact">
+                                <thead>
+                                    <tr>
+                                        <th>Product</th>
+                                        <th>Quantity</th>
+                                        <th>Unit Price</th>
+                                        <th>Line Total</th>
+                                        <th>Actions</th>
                                     </tr>
-                                ))}
-                            </tbody>
-                        </Table>
+                                </thead>
+                                <tbody>
+                                    {lineItems.map((item, index) => (
+                                        <tr key={index}>
+                                            <td>
+                                                <Form.Select
+                                                    name="product_id"
+                                                    value={item.product_id}
+                                                    onChange={(e) => handleLineItemChange(index, e)}
+                                                >
+                                                    <option>Select Product</option>
+                                                    {allProducts.map((product) => (
+                                                        <option key={product.id} value={product.id}>
+                                                            {product.name}
+                                                        </option>
+                                                    ))}
+                                                </Form.Select>
+                                            </td>
+                                            <td>
+                                                <Form.Control
+                                                    type="number"
+                                                    name="quantity"
+                                                    value={item.quantity}
+                                                    onChange={(e) => handleLineItemChange(index, e)}
+                                                />
+                                            </td>
+                                            <td>
+                                                <Form.Control
+                                                    type="number"
+                                                    step="0.01"
+                                                    name="unit_price"
+                                                    value={item.unit_price}
+                                                    onChange={(e) => handleLineItemChange(index, e)}
+                                                />
+                                            </td>
+                                            <td>
+                                                {new Intl.NumberFormat('en-US', {
+                                                    style: 'currency',
+                                                    currency: customer.currency,
+                                                }).format(item.quantity * item.unit_price)}
+                                            </td>
+                                            <td>
+                                                <Button variant="danger" onClick={() => handleRemoveItem(index)}>
+                                                    <Trash />
+                                                </Button>
+                                            </td>
+                                        </tr>
+                                    ))}
+                                </tbody>
+                            </Table>
+                        </div>
                         <Button variant="secondary" onClick={handleAddItem}>+ Add Item</Button>
 
                         <div className="d-flex justify-content-end mt-3">

--- a/frontend/src/pages/SaleListPage.js
+++ b/frontend/src/pages/SaleListPage.js
@@ -5,6 +5,7 @@ import { Link } from 'react-router-dom';
 import axiosInstance from '../utils/axiosInstance';
 import { Card, Button, Table, Alert, Spinner } from 'react-bootstrap';
 import { formatCurrency } from '../utils/format';
+import '../styles/datatable.css';
 
 function SaleListPage() {
     const [sales, setSales] = useState([]);
@@ -44,41 +45,43 @@ function SaleListPage() {
             </Card.Header>
             <Card.Body>
                 {error && <Alert variant="danger">{error}</Alert>}
-                <Table striped bordered hover responsive>
-                    <thead>
-                        <tr>
-                            <th>#</th>
-                            <th>Invoice No.</th>
-                            <th>Customer</th>
-                            <th>Date</th>
-                            <th>Total Amount</th>
-                            <th>Actions</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {sales.length > 0 ? (
-                            sales.map((sale, index) => (
-                                <tr key={sale.id}>
-                                    <td>{index + 1}</td>
-                                    <td>{sale.invoice_number || `SALE-${sale.id}`}</td>
-                                    {/* 'customer_name' comes from our SaleReadSerializer */}
-                                    <td>{sale.customer_name}</td>
-                                    <td>{new Date(sale.sale_date).toLocaleDateString()}</td>
-                                    <td>{formatCurrency(sale.total_amount, sale.original_currency || 'USD')}</td>
-                                    <td>
-                                        <Button as={Link} to={`/sales/${sale.id}`} variant="outline" size="sm">
-                                        View
-                                    </Button>
-                                    </td>
-                                </tr>
-                            ))
-                        ) : (
+                <div className="data-table-container">
+                    <Table responsive className="data-table">
+                        <thead>
                             <tr>
-                                <td colSpan="6" className="text-center">No sales found.</td>
+                                <th>#</th>
+                                <th>Invoice No.</th>
+                                <th>Customer</th>
+                                <th>Date</th>
+                                <th>Total Amount</th>
+                                <th>Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {sales.length > 0 ? (
+                                sales.map((sale, index) => (
+                                    <tr key={sale.id}>
+                                        <td>{index + 1}</td>
+                                        <td>{sale.invoice_number || `SALE-${sale.id}`}</td>
+                                        {/* 'customer_name' comes from our SaleReadSerializer */}
+                                        <td>{sale.customer_name}</td>
+                                        <td>{new Date(sale.sale_date).toLocaleDateString()}</td>
+                                        <td>{formatCurrency(sale.total_amount, sale.original_currency || 'USD')}</td>
+                                        <td>
+                                            <Button as={Link} to={`/sales/${sale.id}`} variant="outline" size="sm">
+                                                View
+                                            </Button>
+                                        </td>
+                                    </tr>
+                                ))
+                            ) : (
+                            <tr>
+                                <td colSpan="6" className="data-table-empty">No sales found.</td>
                             </tr>
                         )}
-                    </tbody>
-                </Table>
+                        </tbody>
+                    </Table>
+                </div>
             </Card.Body>
         </Card>
     );

--- a/frontend/src/pages/SalesReportPage.js
+++ b/frontend/src/pages/SalesReportPage.js
@@ -3,6 +3,7 @@ import axiosInstance from '../utils/axiosInstance';
 import { Card, Button, Form, Row, Col, Spinner, Alert, Table, Collapse } from 'react-bootstrap';
 import { formatCurrency } from '../utils/format';
 import { downloadBlobResponse } from '../utils/download';
+import '../styles/datatable.css';
 
 // Helper to get the first day of the current month
 const getFirstDayOfMonth = () => {
@@ -158,8 +159,8 @@ function SalesReportPage() {
                                 )}
                             </Button>
                         </div>
-                        <div className="mt-4">
-                            <Table striped bordered hover responsive>
+                        <div className="mt-4 data-table-container">
+                            <Table responsive className="data-table">
                                 <thead>
                                     <tr>
                                         <th>#</th>
@@ -172,7 +173,7 @@ function SalesReportPage() {
                                 <tbody>
                                     {reportData.map((sale) => (
                                         <React.Fragment key={sale.id}>
-                                            <tr onClick={() => openRow(sale.id)} style={{ cursor: 'pointer' }}>
+                                            <tr onClick={() => openRow(sale.id)} className="data-table-row--link">
                                                 <td>
                                                     <Button
                                                         variant="link"
@@ -193,7 +194,10 @@ function SalesReportPage() {
                                                         <Card className="m-2">
                                                             <Card.Body>
                                                                 <h5>Sale Items</h5>
-                                                                <Table size="sm">
+                                                                <Table
+                                                                    size="sm"
+                                                                    className="data-table data-table--compact data-table--subtle"
+                                                                >
                                                                     <thead>
                                                                         <tr>
                                                                             <th>Product</th>

--- a/frontend/src/pages/SupplierDetailPage.js
+++ b/frontend/src/pages/SupplierDetailPage.js
@@ -8,6 +8,7 @@ import { PersonCircle, Cash, Tag, Hammer, BarChart, PencilSquare, Trash } from '
 import './SupplierDetailPage.css';
 import SupplierPaymentModal from '../components/SupplierPaymentModal';
 import ActionMenu from '../components/ActionMenu';
+import '../styles/datatable.css';
 
 const API_BASE_URL = 'http://127.0.0.1:8000';
 
@@ -225,7 +226,7 @@ function SupplierDetailPage() {
                                                         ]}
                                                     />
                                                 </div>
-                                                <Table striped bordered hover size="sm">
+                                                <Table size="sm" className="data-table data-table--compact data-table--subtle">
                                                     <thead>
                                                         <tr>
                                                             <th>Product</th>
@@ -286,7 +287,7 @@ function SupplierDetailPage() {
                                                         ]}
                                                     />
                                                 </div>
-                                                <Table striped bordered hover size="sm">
+                                                <Table size="sm" className="data-table data-table--compact data-table--subtle">
                                                     <thead>
                                                         <tr>
                                                             <th>Product</th>
@@ -349,7 +350,7 @@ function SupplierDetailPage() {
                                                         ]}
                                                     />
                                                 </div>
-                                                <Table borderless size="sm" className="mb-0">
+                                                <Table size="sm" className="data-table data-table--compact data-table--subtle mb-0">
                                                     <tbody>
                                                         <tr>
                                                             <td className="fw-bold">Account</td>

--- a/frontend/src/pages/SupplierListPage.js
+++ b/frontend/src/pages/SupplierListPage.js
@@ -5,6 +5,7 @@ import { useNavigate } from 'react-router-dom';
 import axiosInstance from '../utils/axiosInstance';
 import { Table, Button, Form, InputGroup, Row, Col, Spinner, Alert } from 'react-bootstrap';
 import { Plus } from 'react-bootstrap-icons';
+import '../styles/datatable.css';
 
 function SupplierListPage() {
     const [suppliers, setSuppliers] = useState([]);
@@ -46,7 +47,7 @@ function SupplierListPage() {
         <>
             {error && <Alert variant="danger">{error}</Alert>}
 
-            <Row className="mb-3 align-items-center">
+            <Row className="data-table-toolbar align-items-center">
                 <Col md={6}>
                     <Button variant="success" className="me-2" onClick={() => navigate('/suppliers/new')}>
                         <Plus size={20} className="me-1" /> Add New Supplier
@@ -64,31 +65,35 @@ function SupplierListPage() {
             </Row>
 
             <h2 className="mb-3">Suppliers</h2>
-            <div className="table-container border rounded">
-                <Table striped hover responsive className="m-0">
-                    <thead className="table-dark">
+            <div className="data-table-container">
+                <Table responsive className="data-table">
+                    <thead>
                         <tr>
-                            <th style={{ padding: '1rem' }}>Name / Title</th>
-                            <th style={{ padding: '1rem' }}>Open Balance</th>
+                            <th>Name / Title</th>
+                            <th>Open Balance</th>
                         </tr>
                     </thead>
                     <tbody>
                         {loading ? (
                             <tr>
-                                <td colSpan="2" className="text-center p-5">
+                                <td colSpan="2" className="data-table-status">
                                     <Spinner animation="border" />
                                 </td>
                             </tr>
                         ) : suppliers.length > 0 ? (
                             suppliers.map((supplier) => (
-                                <tr key={supplier.id} onClick={() => navigate(`/suppliers/${supplier.id}`)} style={{ cursor: 'pointer' }}>
+                                <tr
+                                    key={supplier.id}
+                                    onClick={() => navigate(`/suppliers/${supplier.id}`)}
+                                    className="data-table-row--link"
+                                >
                                     <td>{supplier.name}</td>
                                     <td>{formatCurrency(supplier.open_balance, supplier.currency)}</td>
                                 </tr>
                             ))
                         ) : (
                             <tr>
-                                <td colSpan="2" className="text-center p-5">
+                                <td colSpan="2" className="data-table-empty">
                                     {searchTerm ? `No suppliers found for "${searchTerm}".` : 'No suppliers found. Click "Add New Supplier" to get started.'}
                                 </td>
                             </tr>

--- a/frontend/src/pages/TransactionPage.js
+++ b/frontend/src/pages/TransactionPage.js
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import { Form, Button, Card, Row, Col, Table, Alert } from 'react-bootstrap';
 import { formatCurrency } from '../utils/format';
 import { FaTrash } from 'react-icons/fa';
+import '../styles/datatable.css';
 
 function TransactionPage() {
     // State for data fetched from the API
@@ -129,67 +130,69 @@ function TransactionPage() {
                         </Form.Group>
                     </Row>
 
-                      <h5>Sale Items</h5>
-                      <Table bordered hover responsive>
-                        <thead>
-                            <tr>
-                                <th>Product</th>
-                                <th>Quantity</th>
-                                <th>Unit Price</th>
-                                <th>Line Total</th>
-                                <th>Action</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {saleItems.map((item, index) => (
-                                <tr key={index}>
-                                    <td>
-                                        <Form.Select
-                                            name="product_id"
-                                            value={item.product_id}
-                                            onChange={e => handleItemChange(index, e)}
-                                            required
-                                        >
-                                            <option value="">Select a Product</option>
-                                            {products.map(product => (
-                                                <option key={product.id} value={product.id}>
-                                                    {product.name}
-                                                </option>
-                                            ))}
-                                        </Form.Select>
-                                    </td>
-                                    <td>
-                                        <Form.Control
-                                            type="number"
-                                            name="quantity"
-                                            value={item.quantity}
-                                            onChange={e => handleItemChange(index, e)}
-                                            min="1"
-                                            required
-                                        />
-                                    </td>
-                                    <td>
-                                        <Form.Control
-                                            type="number"
-                                            name="unit_price"
-                                            value={item.unit_price}
-                                            onChange={e => handleItemChange(index, e)}
-                                            step="0.01"
-                                            required
-                                        />
-                                    </td>
-                                    <td>
-                                        {formatCurrency((Number(item.quantity) || 0) * (Number(item.unit_price) || 0))}
-                                    </td>
-                                    <td>
-                                        <Button variant="danger" onClick={() => handleRemoveItem(index)}>
-                                            <FaTrash />
-                                        </Button>
-                                    </td>
+                    <h5>Sale Items</h5>
+                    <div className="data-table-container">
+                        <Table responsive className="data-table data-table--compact">
+                            <thead>
+                                <tr>
+                                    <th>Product</th>
+                                    <th>Quantity</th>
+                                    <th>Unit Price</th>
+                                    <th>Line Total</th>
+                                    <th>Action</th>
                                 </tr>
-                            ))}
-                        </tbody>
-                    </Table>
+                            </thead>
+                            <tbody>
+                                {saleItems.map((item, index) => (
+                                    <tr key={index}>
+                                        <td>
+                                            <Form.Select
+                                                name="product_id"
+                                                value={item.product_id}
+                                                onChange={(e) => handleItemChange(index, e)}
+                                                required
+                                            >
+                                                <option value="">Select a Product</option>
+                                                {products.map((product) => (
+                                                    <option key={product.id} value={product.id}>
+                                                        {product.name}
+                                                    </option>
+                                                ))}
+                                            </Form.Select>
+                                        </td>
+                                        <td>
+                                            <Form.Control
+                                                type="number"
+                                                name="quantity"
+                                                value={item.quantity}
+                                                onChange={(e) => handleItemChange(index, e)}
+                                                min="1"
+                                                required
+                                            />
+                                        </td>
+                                        <td>
+                                            <Form.Control
+                                                type="number"
+                                                name="unit_price"
+                                                value={item.unit_price}
+                                                onChange={(e) => handleItemChange(index, e)}
+                                                step="0.01"
+                                                required
+                                            />
+                                        </td>
+                                        <td>
+                                            {formatCurrency((Number(item.quantity) || 0) * (Number(item.unit_price) || 0))}
+                                        </td>
+                                        <td>
+                                            <Button variant="danger" onClick={() => handleRemoveItem(index)}>
+                                                <FaTrash />
+                                            </Button>
+                                        </td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </Table>
+                    </div>
 
                     <Button variant="secondary" onClick={handleAddItem} className="mb-3">
                         + Add Item

--- a/frontend/src/styles/datatable.css
+++ b/frontend/src/styles/datatable.css
@@ -1,0 +1,147 @@
+.data-table-container {
+  background: var(--color-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: 0.9rem;
+  box-shadow: var(--shadow-sm);
+  overflow: hidden;
+}
+
+.data-table-container .table-responsive {
+  margin-bottom: 0;
+  background: transparent;
+}
+
+.table-responsive .data-table {
+  margin-bottom: 0;
+}
+
+.table-responsive .data-table thead th:first-child {
+  border-top-left-radius: 0.9rem;
+}
+
+.table-responsive .data-table thead th:last-child {
+  border-top-right-radius: 0.9rem;
+}
+
+.data-table {
+  width: 100%;
+  color: var(--text-primary);
+  background-color: transparent;
+  border-collapse: separate;
+  border-spacing: 0;
+}
+
+.data-table thead th {
+  background: linear-gradient(135deg, rgba(20, 32, 68, 0.94), rgba(37, 99, 235, 0.16));
+  color: var(--text-primary);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 0.85rem 1rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.22);
+}
+
+.data-table tbody tr {
+  transition: background-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.data-table tbody td {
+  padding: 0.9rem 1rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+  color: var(--text-primary);
+  vertical-align: middle;
+}
+
+.data-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.data-table tbody tr:hover,
+.data-table tbody tr:focus-within {
+  background: rgba(37, 99, 235, 0.12);
+}
+
+.data-table tbody tr:focus-within {
+  outline: none;
+  box-shadow: inset 0 0 0 1px var(--border-strong);
+}
+
+.data-table-row--link {
+  cursor: pointer;
+}
+
+.data-table-row--link:focus-within td:first-child,
+.data-table-row--link:hover td:first-child {
+  border-top-left-radius: 0.4rem;
+}
+
+.data-table-row--link:focus-within td:last-child,
+.data-table-row--link:hover td:last-child {
+  border-top-right-radius: 0.4rem;
+}
+
+.data-table-empty,
+.data-table-status {
+  padding: 2.75rem 1rem;
+  text-align: center;
+  color: var(--text-secondary);
+}
+
+.data-table-empty strong {
+  color: var(--text-primary);
+}
+
+.data-table-toolbar {
+  row-gap: 1rem;
+  margin-bottom: 1.5rem;
+  align-items: center;
+}
+
+.data-table-toolbar .btn,
+.data-table-toolbar .form-control {
+  border-radius: 0.65rem;
+}
+
+.data-table-pagination {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 0.75rem;
+  padding-top: 1rem;
+}
+
+.data-table--compact thead th,
+.data-table--compact tbody td {
+  padding: 0.6rem 0.75rem;
+  font-size: 0.875rem;
+}
+
+.data-table--subtle tbody td {
+  color: var(--text-secondary);
+}
+
+.data-table tr.table-success td {
+  background: rgba(34, 197, 94, 0.18);
+  color: var(--text-primary);
+}
+
+.data-table tr.table-danger td {
+  background: rgba(239, 68, 68, 0.18);
+  color: var(--text-primary);
+}
+
+.data-table tr.table-info td {
+  background: rgba(59, 130, 246, 0.18);
+  color: var(--text-primary);
+}
+
+.data-table thead th.text-end,
+.data-table tbody td.text-end {
+  text-align: right;
+}
+
+.data-table thead th.text-center,
+.data-table tbody td.text-center {
+  text-align: center;
+}


### PR DESCRIPTION
## Summary
- add a shared data table stylesheet that applies themed containers, header contrast, hover states, and compact variants
- update list, report, and form pages to import the shared styling, swap Bootstrap props for the new `data-table` classes, and normalize empty states
- refresh detail views and nested tables so that compact tables and payment history blocks adopt the same hover, focus, and spacing rules

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce516067988323911a0db853668597