### PR TITLE
Fix customer table text contrast

### DIFF
--- a/frontend/src/styles/datatable.css
+++ b/frontend/src/styles/datatable.css
@@ -56,15 +56,13 @@
 
 .data-table tbody tr {
   transition: background-color 0.2s ease, box-shadow 0.2s ease;
+  background-color: var(--color-neutral-50, #f8fafc);
 }
 
 .data-table tbody td {
   padding: 0.9rem 1rem;
-  border-bottom: 1px solid rgba(148, 163, 184, 0.16);
-  color: var(--text-color-primary, var(--color-neutral-900, #0f172a));
-
   border-bottom: 1px solid rgba(148, 163, 184, 0.18);
-  color: var(--text-primary);
+  color: var(--text-color-primary, var(--color-neutral-900, #0f172a));
   vertical-align: middle;
 }
 


### PR DESCRIPTION
## Summary
- add a light background color to data table rows so content stays visible on neutral surfaces
- set table cell text to use the primary text color token instead of the inverse theme color

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce5ecc4a0c8323b0532b2f51902379