### PR TITLE
Tighten transaction history headers

### DIFF
--- a/frontend/src/styles/transaction-history.css
+++ b/frontend/src/styles/transaction-history.css
@@ -15,8 +15,8 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-    gap: 1rem;
-    padding: 1.5rem;
+    gap: 0.85rem;
+    padding: 1.1rem 1.25rem;
     border-bottom: none;
     color: #ffffff;
     background: linear-gradient(135deg, #0f172a, #1e293b);
@@ -25,19 +25,22 @@
 .transaction-history-card__eyebrow {
     text-transform: uppercase;
     letter-spacing: 0.14em;
-    font-size: 0.7rem;
+    font-size: 0.65rem;
     opacity: 0.72;
+    color: #ffffff;
     display: block;
     margin-bottom: 0.35rem;
 }
 
 .transaction-history-card__title {
     font-weight: 600;
+    font-size: 1.05rem;
+    color: #ffffff;
 }
 
 .transaction-history-card__subtitle {
-    font-size: 0.86rem;
-    opacity: 0.8;
+    font-size: 0.8rem;
+    color: #ffffff;
     margin-bottom: 0;
 }
 
@@ -45,7 +48,7 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    padding: 0.75rem;
+    padding: 0.55rem;
     border-radius: 16px;
     background: rgba(255, 255, 255, 0.22);
     color: inherit;
@@ -53,8 +56,8 @@
 }
 
 .transaction-history-card__icon svg {
-    width: 24px;
-    height: 24px;
+    width: 20px;
+    height: 20px;
 }
 
 .transaction-history-card--sales .transaction-history-card__header {


### PR DESCRIPTION
## Summary
- reduce the spacing inside transaction history headers so the cards take up less space
- enforce white text on the history eyebrow, title, and subtitle for readability on gradients
- scale down the header icon container and icon to match the more compact layout

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68ce89e3b8e083238ba4f08c22fb0bf5