### PR TITLE
Add dedicated customer and supplier payment pages

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -20,6 +20,8 @@ import SupplierFormPage from './pages/SupplierFormPage';
 import SaleListPage from './pages/SaleListPage'; // <-- Import
 import TransactionPage from './pages/TransactionPage';   // <-- Import
 import SaleDetailPage from './pages/SaleDetailPage';
+import CustomerPaymentPage from './pages/CustomerPaymentPage';
+import SupplierPaymentPage from './pages/SupplierPaymentPage';
 import ExpenseListPage from './pages/ExpenseListPage';
 import ProfitLossPage from './pages/ProfitLossPage';
 import SalesReportPage from './pages/SalesReportPage';
@@ -62,6 +64,7 @@ function App() {
                   <Route path="customers/new" element={<CustomerFormPage />} /> 
                   <Route path="customers/edit/:id" element={<CustomerFormPage />} />
                   <Route path="customers/:id" element={<CustomerDetailPage />} />
+                  <Route path="customers/:id/payment" element={<CustomerPaymentPage />} />
                   <Route path="inventory" element={<ProductListPage />} /> {/* <-- Add Route */}
                   <Route path="inventory/new" element={<ProductFormPage />} /> {/* <-- Add Route */}
                   <Route path="inventory/edit/:id" element={<ProductFormPage />} /> {/* <-- Add Route */}
@@ -71,6 +74,7 @@ function App() {
                   <Route path="suppliers/new" element={<SupplierFormPage />} />
                   <Route path="suppliers/edit/:id" element={<SupplierFormPage />} />
                   <Route path="suppliers/:id" element={<SupplierDetailPage />} />
+                  <Route path="suppliers/:id/payment" element={<SupplierPaymentPage />} />
                   <Route path="suppliers/:supplierId/new-purchase" element={<PurchaseFormPage />} />
                   <Route path="suppliers/:supplierId/new-sale" element={<SaleFormPage />} />
                   <Route path="sales" element={<SaleListPage />} />

--- a/frontend/src/pages/CustomerDetailPage.js
+++ b/frontend/src/pages/CustomerDetailPage.js
@@ -174,7 +174,13 @@ function CustomerDetailPage() {
                 >
                     Buy from Customer
                 </Button>
-                <Button variant="success" className="me-2" onClick={() => setShowPaymentModal(true)}>Collection / Payment</Button>
+                <Button
+                    variant="success"
+                    className="me-2"
+                    onClick={() => navigate(`/customers/${customer.id}/payment`)}
+                >
+                    Collection / Payment
+                </Button>
             </ButtonToolbar>
 
             <CustomerPaymentModal

--- a/frontend/src/pages/CustomerPaymentPage.js
+++ b/frontend/src/pages/CustomerPaymentPage.js
@@ -1,0 +1,444 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { Alert, Button, Card, Col, Container, Form, Row, Spinner } from 'react-bootstrap';
+import axiosInstance from '../utils/axiosInstance';
+import { getCurrencyOptions, loadCurrencyOptions } from '../config/currency';
+import '../styles/payment-page.css';
+
+const getTodayDate = () => {
+    const today = new Date();
+    const yyyy = today.getFullYear();
+    const mm = String(today.getMonth() + 1).padStart(2, '0');
+    const dd = String(today.getDate()).padStart(2, '0');
+    return `${yyyy}-${mm}-${dd}`;
+};
+
+const formatCurrency = (value, currency) => {
+    const amount = Number(value) || 0;
+    try {
+        return new Intl.NumberFormat('en-US', {
+            style: 'currency',
+            currency: currency || 'USD',
+        }).format(amount);
+    } catch (error) {
+        return `${amount.toFixed(2)} ${currency || ''}`.trim();
+    }
+};
+
+const buildErrorMessage = (error) => {
+    if (!error) return 'Could not save the payment. Please try again.';
+    if (typeof error === 'string') return error;
+    if (Array.isArray(error)) {
+        return error.map(buildErrorMessage).join(' ');
+    }
+    if (typeof error === 'object') {
+        if (error.detail) return buildErrorMessage(error.detail);
+        return Object.entries(error)
+            .map(([field, messages]) => `${field}: ${buildErrorMessage(messages)}`)
+            .join(' ');
+    }
+    return 'Could not save the payment. Please try again.';
+};
+
+const describeOpenBalance = (value) => {
+    const numeric = Number(value) || 0;
+    if (numeric > 0) return 'Müşteri size borçlu.';
+    if (numeric < 0) return 'Müşteriye borçlusunuz.';
+    return 'Hesap kapandı.';
+};
+
+function CustomerPaymentPage() {
+    const { id } = useParams();
+    const navigate = useNavigate();
+
+    const [customerData, setCustomerData] = useState(null);
+    const [accounts, setAccounts] = useState([]);
+    const [currencyOptions, setCurrencyOptions] = useState([]);
+
+    const [transactionType, setTransactionType] = useState('collection');
+    const [paymentDate, setPaymentDate] = useState(getTodayDate());
+    const [method, setMethod] = useState('Cash');
+    const [notes, setNotes] = useState('');
+    const [account, setAccount] = useState('');
+    const [amount, setAmount] = useState('');
+    const [paymentCurrency, setPaymentCurrency] = useState('');
+    const [exchangeRate, setExchangeRate] = useState(1);
+
+    const [loading, setLoading] = useState(true);
+    const [saving, setSaving] = useState(false);
+    const [error, setError] = useState('');
+    const [success, setSuccess] = useState('');
+
+    const customerCurrency = customerData?.customer?.currency || 'USD';
+    const customerName = customerData?.customer?.name || '';
+    const summary = customerData?.summary || null;
+
+    useEffect(() => {
+        const ensureCurrencyOptions = async () => {
+            const options = getCurrencyOptions();
+            if (options.length === 0) {
+                const loadedOptions = await loadCurrencyOptions();
+                setCurrencyOptions(loadedOptions);
+            } else {
+                setCurrencyOptions(options);
+            }
+        };
+        ensureCurrencyOptions();
+    }, []);
+
+    const fetchInitialData = async () => {
+        setLoading(true);
+        setError('');
+        try {
+            const [detailsRes, accountsRes] = await Promise.all([
+                axiosInstance.get(`/customers/${id}/details/`),
+                axiosInstance.get('/accounts/'),
+            ]);
+            setCustomerData(detailsRes.data);
+            setAccounts(accountsRes.data || []);
+            const defaultCurrency = detailsRes.data?.customer?.currency || 'USD';
+            setPaymentCurrency(defaultCurrency);
+            setTransactionType('collection');
+            setPaymentDate(getTodayDate());
+            setAmount('');
+            setNotes('');
+            setAccount('');
+            setMethod('Cash');
+            setExchangeRate(1);
+        } catch (err) {
+            console.error('Failed to load customer payment data:', err);
+            setError('Failed to load customer information for payment.');
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        fetchInitialData();
+    }, [id]);
+
+    const refreshCustomerSummary = async () => {
+        try {
+            const detailsRes = await axiosInstance.get(`/customers/${id}/details/`);
+            setCustomerData(detailsRes.data);
+        } catch (err) {
+            console.error('Failed to refresh customer summary:', err);
+        }
+    };
+
+    const handleAccountChange = (event) => {
+        const selectedValue = event.target.value;
+        setAccount(selectedValue);
+        const selectedAccount = accounts.find((acc) => acc.id === Number(selectedValue));
+        if (selectedAccount) {
+            setPaymentCurrency(selectedAccount.currency);
+            setExchangeRate(1);
+        } else {
+            setPaymentCurrency(customerCurrency);
+        }
+    };
+
+    const requiresExchangeRate = useMemo(
+        () => !account && paymentCurrency && paymentCurrency !== customerCurrency,
+        [account, paymentCurrency, customerCurrency],
+    );
+
+    const convertedAmountValue = useMemo(() => {
+        const numericAmount = parseFloat(amount) || 0;
+        const rate = parseFloat(exchangeRate) || 1;
+        const sign = transactionType === 'collection' ? 1 : -1;
+        return numericAmount * rate * sign;
+    }, [amount, exchangeRate, transactionType]);
+
+    const handleCurrencyChange = (newCurrency) => {
+        setPaymentCurrency(newCurrency);
+        if (newCurrency === customerCurrency) {
+            setExchangeRate(1);
+        }
+    };
+
+    const handleSubmit = async (event) => {
+        event.preventDefault();
+        if (!customerData) return;
+
+        setError('');
+        setSuccess('');
+
+        const numericAmount = parseFloat(amount);
+        if (!numericAmount || numericAmount <= 0) {
+            setError('Please enter a valid amount greater than zero.');
+            return;
+        }
+
+        const selectedAccount = accounts.find((acc) => acc.id === Number(account));
+        if (!selectedAccount && requiresExchangeRate) {
+            const rate = parseFloat(exchangeRate);
+            if (!rate || rate <= 0) {
+                setError('Please provide a valid exchange rate.');
+                return;
+            }
+        }
+
+        const finalAmount = transactionType === 'collection' ? numericAmount : -numericAmount;
+
+        const payload = {
+            payment_date: paymentDate,
+            original_amount: finalAmount,
+            method,
+            notes,
+        };
+
+        if (selectedAccount) {
+            payload.account = selectedAccount.id;
+        } else {
+            payload.original_currency = paymentCurrency || customerCurrency;
+            if (requiresExchangeRate) {
+                payload.exchange_rate = parseFloat(exchangeRate);
+            }
+        }
+
+        try {
+            setSaving(true);
+            await axiosInstance.post(`/customers/${id}/payments/`, payload);
+            setSuccess('Payment recorded successfully.');
+            setAmount('');
+            setNotes('');
+            setAccount('');
+            setMethod('Cash');
+            setTransactionType('collection');
+            setPaymentCurrency(customerCurrency);
+            setExchangeRate(1);
+            await refreshCustomerSummary();
+        } catch (err) {
+            console.error('Failed to save payment:', err);
+            const message = buildErrorMessage(err?.response?.data) || 'Could not save the payment. Please try again.';
+            setError(message);
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    return (
+        <Container fluid className="payment-page">
+            <div className="payment-page__header">
+                <Button
+                    type="submit"
+                    form="customer-payment-form"
+                    className="payment-page__save-btn"
+                    disabled={loading || saving}
+                >
+                    {saving ? 'Kaydediliyor…' : 'Kaydet'}
+                </Button>
+                <Button
+                    type="button"
+                    className="payment-page__back-btn"
+                    onClick={() => navigate(`/customers/${id}`)}
+                >
+                    Müşteri Sayfası
+                </Button>
+            </div>
+
+            {error && <Alert variant="danger" className="payment-page__alert">{error}</Alert>}
+            {success && <Alert variant="success" className="payment-page__alert">{success}</Alert>}
+
+            {loading ? (
+                <div className="text-center py-5">
+                    <Spinner animation="border" variant="primary" />
+                </div>
+            ) : (
+                <Row className="g-4">
+                    <Col lg={8}>
+                        <Card className="payment-form-card">
+                            <div className="payment-form-card__header">
+                                <div className="payment-form-card__title">GİRİŞ</div>
+                                <h5 className="payment-form-card__subtitle">Müşteri Tahsilatı Kaydı</h5>
+                            </div>
+                            <Card.Body>
+                                <Form id="customer-payment-form" onSubmit={handleSubmit}>
+                                    <Row className="g-3">
+                                        <Col md={6}>
+                                            <Form.Group controlId="transactionType">
+                                                <Form.Label>İşlem</Form.Label>
+                                                <Form.Select
+                                                    value={transactionType}
+                                                    onChange={(event) => setTransactionType(event.target.value)}
+                                                    disabled={saving}
+                                                >
+                                                    <option value="collection">Müşteriden Tahsilat</option>
+                                                    <option value="refund">Müşteriye Ödeme</option>
+                                                </Form.Select>
+                                            </Form.Group>
+                                        </Col>
+                                        <Col md={6}>
+                                            <Form.Group controlId="paymentDate">
+                                                <Form.Label>Tarih</Form.Label>
+                                                <Form.Control
+                                                    type="date"
+                                                    value={paymentDate}
+                                                    onChange={(event) => setPaymentDate(event.target.value)}
+                                                    disabled={saving}
+                                                    required
+                                                />
+                                            </Form.Group>
+                                        </Col>
+                                        <Col md={6}>
+                                            <Form.Group controlId="method">
+                                                <Form.Label>Ödeme Yöntemi</Form.Label>
+                                                <Form.Select
+                                                    value={method}
+                                                    onChange={(event) => setMethod(event.target.value)}
+                                                    disabled={saving}
+                                                >
+                                                    <option value="Cash">Nakit</option>
+                                                    <option value="Bank">Banka Transferi</option>
+                                                    <option value="Card">Kart</option>
+                                                </Form.Select>
+                                            </Form.Group>
+                                        </Col>
+                                        <Col md={6}>
+                                            <Form.Group controlId="account">
+                                                <Form.Label>Kasa / Hesap</Form.Label>
+                                                <Form.Select
+                                                    value={account}
+                                                    onChange={handleAccountChange}
+                                                    disabled={saving}
+                                                >
+                                                    <option value="">Hesap seçin</option>
+                                                    {accounts.map((acc) => (
+                                                        <option key={acc.id} value={acc.id}>
+                                                            {acc.name} ({acc.currency})
+                                                        </option>
+                                                    ))}
+                                                </Form.Select>
+                                            </Form.Group>
+                                        </Col>
+                                        <Col md={6}>
+                                            <Form.Group controlId="amount">
+                                                <Form.Label>Tutar ({paymentCurrency || customerCurrency})</Form.Label>
+                                                <Form.Control
+                                                    type="number"
+                                                    min="0"
+                                                    step="0.01"
+                                                    value={amount}
+                                                    onChange={(event) => setAmount(event.target.value)}
+                                                    placeholder="Ödeme tutarını girin"
+                                                    disabled={saving}
+                                                    required
+                                                />
+                                            </Form.Group>
+                                        </Col>
+                                        <Col md={6}>
+                                            <Form.Group controlId="paymentCurrency">
+                                                <Form.Label>Para Birimi</Form.Label>
+                                                <Form.Select
+                                                    value={paymentCurrency}
+                                                    onChange={(event) => handleCurrencyChange(event.target.value)}
+                                                    disabled={saving || Boolean(account)}
+                                                >
+                                                    {(currencyOptions.length ? currencyOptions : [customerCurrency]).map((currency) => (
+                                                        <option key={currency} value={currency}>
+                                                            {currency}
+                                                        </option>
+                                                    ))}
+                                                </Form.Select>
+                                            </Form.Group>
+                                        </Col>
+
+                                        {requiresExchangeRate && (
+                                            <>
+                                                <Col md={6}>
+                                                    <Form.Group controlId="exchangeRate">
+                                                        <Form.Label>Kur ({paymentCurrency} ➜ {customerCurrency})</Form.Label>
+                                                        <Form.Control
+                                                            type="number"
+                                                            step="0.0001"
+                                                            min="0"
+                                                            value={exchangeRate}
+                                                            onChange={(event) => setExchangeRate(event.target.value)}
+                                                            disabled={saving}
+                                                            required
+                                                        />
+                                                    </Form.Group>
+                                                </Col>
+                                                <Col md={6}>
+                                                    <div className="payment-form-card__converted">
+                                                        <div className="small text-uppercase text-muted">Müşteri bakiyesine yansıyan</div>
+                                                        <div>{formatCurrency(convertedAmountValue, customerCurrency)}</div>
+                                                    </div>
+                                                </Col>
+                                            </>
+                                        )}
+                                        {!requiresExchangeRate && (
+                                            <Col md={6}>
+                                                <div className="payment-form-card__converted">
+                                                    <div className="small text-uppercase text-muted">Müşteri bakiyesine yansıyan</div>
+                                                    <div>{formatCurrency(convertedAmountValue, customerCurrency)}</div>
+                                                </div>
+                                            </Col>
+                                        )}
+                                        <Col xs={12}>
+                                            <Form.Group controlId="notes">
+                                                <Form.Label>Açıklama</Form.Label>
+                                                <Form.Control
+                                                    as="textarea"
+                                                    rows={3}
+                                                    value={notes}
+                                                    onChange={(event) => setNotes(event.target.value)}
+                                                    placeholder="İsteğe bağlı açıklama ekleyin"
+                                                    disabled={saving}
+                                                />
+                                            </Form.Group>
+                                        </Col>
+                                    </Row>
+                                    <div className="payment-form-card__note mt-3">
+                                        {transactionType === 'collection'
+                                            ? 'Bu kayıt müşteriden tahsilat olarak işlenecek.'
+                                            : 'Bu kayıt müşteriye ödeme olarak işlenecek.'}
+                                    </div>
+                                </Form>
+                            </Card.Body>
+                        </Card>
+                    </Col>
+                    <Col lg={4}>
+                        <Card className="payment-side-card">
+                            <div className="payment-side-card__header">
+                                <div className="payment-side-card__name">{customerName || 'Müşteri'}</div>
+                                <div className="payment-side-card__meta">
+                                    {customerData?.customer?.email || 'E-posta bilgisi yok'}
+                                </div>
+                                <div className="payment-side-card__meta">
+                                    {customerData?.customer?.phone || 'Telefon bilgisi yok'}
+                                </div>
+                            </div>
+                            <div className="payment-summary">
+                                <div className="payment-summary__item">
+                                    <div className="payment-summary__label">Açık Hesap Bakiyesi</div>
+                                    <div className="payment-summary__value">
+                                        {formatCurrency(summary?.open_balance || 0, customerCurrency)}
+                                    </div>
+                                    <div className="payment-summary__hint">{describeOpenBalance(summary?.open_balance)}</div>
+                                </div>
+                                <div className="payment-summary__item">
+                                    <div className="payment-summary__label">Çek / Senet Bakiyesi</div>
+                                    <div className="payment-summary__value">
+                                        {formatCurrency(summary?.check_balance || 0, customerCurrency)}
+                                    </div>
+                                    <div className="payment-summary__hint">Kayıtlı çek / senet bakiyesi</div>
+                                </div>
+                                <div className="payment-summary__item">
+                                    <div className="payment-summary__label">Banka Bilgileri</div>
+                                    <div className="payment-summary__value">
+                                        {customerData?.customer?.address ? customerData.customer.address : 'Kayıtlı değil'}
+                                    </div>
+                                    <div className="payment-summary__hint">Banka detaylarını müşteri profiline ekleyebilirsiniz.</div>
+                                </div>
+                            </div>
+                        </Card>
+                    </Col>
+                </Row>
+            )}
+        </Container>
+    );
+}
+
+export default CustomerPaymentPage;

--- a/frontend/src/pages/SupplierDetailPage.js
+++ b/frontend/src/pages/SupplierDetailPage.js
@@ -176,7 +176,7 @@ function SupplierDetailPage() {
                 <Button
                     variant="success"
                     className="me-2"
-                    onClick={() => setShowPaymentModal(true)}
+                    onClick={() => navigate(`/suppliers/${supplier.id}/payment`)}
                 >
                     Make Payment
                 </Button>

--- a/frontend/src/pages/SupplierPaymentPage.js
+++ b/frontend/src/pages/SupplierPaymentPage.js
@@ -1,0 +1,355 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { Alert, Button, Card, Col, Container, Form, Row, Spinner } from 'react-bootstrap';
+import axiosInstance from '../utils/axiosInstance';
+import { getBaseCurrency, loadBaseCurrency } from '../config/currency';
+import '../styles/payment-page.css';
+
+const getTodayDate = () => {
+    const today = new Date();
+    const yyyy = today.getFullYear();
+    const mm = String(today.getMonth() + 1).padStart(2, '0');
+    const dd = String(today.getDate()).padStart(2, '0');
+    return `${yyyy}-${mm}-${dd}`;
+};
+
+const formatCurrency = (value, currency) => {
+    const amount = Number(value) || 0;
+    try {
+        return new Intl.NumberFormat('en-US', {
+            style: 'currency',
+            currency: currency || 'USD',
+        }).format(amount);
+    } catch (error) {
+        return `${amount.toFixed(2)} ${currency || ''}`.trim();
+    }
+};
+
+const buildErrorMessage = (error) => {
+    if (!error) return 'Unable to save the payment. Please try again.';
+    if (typeof error === 'string') return error;
+    if (Array.isArray(error)) {
+        return error.map(buildErrorMessage).join(' ');
+    }
+    if (typeof error === 'object') {
+        if (error.detail) return buildErrorMessage(error.detail);
+        return Object.entries(error)
+            .map(([field, messages]) => `${field}: ${buildErrorMessage(messages)}`)
+            .join(' ');
+    }
+    return 'Unable to save the payment. Please try again.';
+};
+
+const describeSupplierBalance = (value) => {
+    const numeric = Number(value) || 0;
+    if (numeric > 0) return 'Tedarikçiye borçlusunuz.';
+    if (numeric < 0) return 'Tedarikçi size borçlu.';
+    return 'Hesap kapandı.';
+};
+
+function SupplierPaymentPage() {
+    const { id } = useParams();
+    const navigate = useNavigate();
+
+    const [supplierData, setSupplierData] = useState(null);
+    const [accounts, setAccounts] = useState([]);
+    const [baseCurrency, setBaseCurrency] = useState(getBaseCurrency());
+
+    const [transactionType, setTransactionType] = useState('payment');
+    const [paymentDate, setPaymentDate] = useState(getTodayDate());
+    const [method, setMethod] = useState('Cash');
+    const [notes, setNotes] = useState('');
+    const [account, setAccount] = useState('');
+    const [amount, setAmount] = useState('');
+
+    const [loading, setLoading] = useState(true);
+    const [saving, setSaving] = useState(false);
+    const [error, setError] = useState('');
+    const [success, setSuccess] = useState('');
+
+    const supplierCurrency = supplierData?.supplier?.currency || baseCurrency || 'USD';
+    const supplierName = supplierData?.supplier?.name || '';
+    const summary = supplierData?.summary || null;
+
+    const fetchInitialData = async () => {
+        setLoading(true);
+        setError('');
+        try {
+            const [detailsRes, accountsRes] = await Promise.all([
+                axiosInstance.get(`suppliers/${id}/details/`),
+                axiosInstance.get('/accounts/'),
+            ]);
+            const loadedBaseCurrency = await loadBaseCurrency().catch(() => getBaseCurrency());
+            setSupplierData(detailsRes.data);
+            setAccounts(accountsRes.data || []);
+            setBaseCurrency(loadedBaseCurrency || getBaseCurrency());
+            setTransactionType('payment');
+            setPaymentDate(getTodayDate());
+            setAmount('');
+            setNotes('');
+            setAccount('');
+            setMethod('Cash');
+        } catch (err) {
+            console.error('Failed to load supplier payment data:', err);
+            setError('Failed to load supplier information for payment.');
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        fetchInitialData();
+    }, [id]);
+
+    const refreshSupplierSummary = async () => {
+        try {
+            const detailsRes = await axiosInstance.get(`suppliers/${id}/details/`);
+            setSupplierData(detailsRes.data);
+        } catch (err) {
+            console.error('Failed to refresh supplier summary:', err);
+        }
+    };
+
+    const handleAccountChange = (event) => {
+        const selectedValue = event.target.value;
+        setAccount(selectedValue);
+    };
+
+    const convertedAmountValue = useMemo(() => {
+        const numeric = parseFloat(amount) || 0;
+        const sign = transactionType === 'payment' ? -1 : 1;
+        return numeric * sign;
+    }, [amount, transactionType]);
+
+    const handleSubmit = async (event) => {
+        event.preventDefault();
+        if (!supplierData) return;
+
+        setError('');
+        setSuccess('');
+
+        const numericAmount = parseFloat(amount);
+        if (!numericAmount || numericAmount <= 0) {
+            setError('Please enter a valid amount greater than zero.');
+            return;
+        }
+
+        const finalAmount = transactionType === 'payment' ? numericAmount : -numericAmount;
+
+        const descriptionParts = [
+            transactionType === 'payment' ? 'Tedarikçiye ödeme' : 'Tedarikçiden tahsilat',
+        ];
+        if (method) {
+            descriptionParts.push(`Yöntem: ${method}`);
+        }
+        if (notes) {
+            descriptionParts.push(notes);
+        }
+
+        const payload = {
+            amount: finalAmount,
+            expense_date: paymentDate,
+            description: descriptionParts.join(' - '),
+            account: account ? Number(account) : null,
+        };
+
+        try {
+            setSaving(true);
+            await axiosInstance.post(`suppliers/${id}/payments/`, payload);
+            setSuccess('Payment saved successfully.');
+            setAmount('');
+            setNotes('');
+            setAccount('');
+            setMethod('Cash');
+            setTransactionType('payment');
+            await refreshSupplierSummary();
+        } catch (err) {
+            console.error('Failed to save supplier payment:', err);
+            const message = buildErrorMessage(err?.response?.data) || 'Unable to save the payment. Please try again.';
+            setError(message);
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    return (
+        <Container fluid className="payment-page">
+            <div className="payment-page__header">
+                <Button
+                    type="submit"
+                    form="supplier-payment-form"
+                    className="payment-page__save-btn"
+                    disabled={loading || saving}
+                >
+                    {saving ? 'Kaydediliyor…' : 'Kaydet'}
+                </Button>
+                <Button
+                    type="button"
+                    className="payment-page__back-btn"
+                    onClick={() => navigate(`/suppliers/${id}`)}
+                >
+                    Tedarikçi Sayfası
+                </Button>
+            </div>
+
+            {error && <Alert variant="danger" className="payment-page__alert">{error}</Alert>}
+            {success && <Alert variant="success" className="payment-page__alert">{success}</Alert>}
+
+            {loading ? (
+                <div className="text-center py-5">
+                    <Spinner animation="border" variant="primary" />
+                </div>
+            ) : (
+                <Row className="g-4">
+                    <Col lg={8}>
+                        <Card className="payment-form-card">
+                            <div className="payment-form-card__header">
+                                <div className="payment-form-card__title">GİRİŞ</div>
+                                <h5 className="payment-form-card__subtitle">Tedarikçiye Ödeme Kaydı</h5>
+                            </div>
+                            <Card.Body>
+                                <Form id="supplier-payment-form" onSubmit={handleSubmit}>
+                                    <Row className="g-3">
+                                        <Col md={6}>
+                                            <Form.Group controlId="transactionType">
+                                                <Form.Label>İşlem</Form.Label>
+                                                <Form.Select
+                                                    value={transactionType}
+                                                    onChange={(event) => setTransactionType(event.target.value)}
+                                                    disabled={saving}
+                                                >
+                                                    <option value="payment">Tedarikçiye Ödeme</option>
+                                                    <option value="collection">Tedarikçiden Tahsilat</option>
+                                                </Form.Select>
+                                            </Form.Group>
+                                        </Col>
+                                        <Col md={6}>
+                                            <Form.Group controlId="paymentDate">
+                                                <Form.Label>Tarih</Form.Label>
+                                                <Form.Control
+                                                    type="date"
+                                                    value={paymentDate}
+                                                    onChange={(event) => setPaymentDate(event.target.value)}
+                                                    disabled={saving}
+                                                    required
+                                                />
+                                            </Form.Group>
+                                        </Col>
+                                        <Col md={6}>
+                                            <Form.Group controlId="method">
+                                                <Form.Label>Ödeme Yöntemi</Form.Label>
+                                                <Form.Select
+                                                    value={method}
+                                                    onChange={(event) => setMethod(event.target.value)}
+                                                    disabled={saving}
+                                                >
+                                                    <option value="Cash">Nakit</option>
+                                                    <option value="Bank">Banka Transferi</option>
+                                                    <option value="Card">Kart</option>
+                                                </Form.Select>
+                                            </Form.Group>
+                                        </Col>
+                                        <Col md={6}>
+                                            <Form.Group controlId="account">
+                                                <Form.Label>Kasa / Hesap</Form.Label>
+                                                <Form.Select
+                                                    value={account}
+                                                    onChange={handleAccountChange}
+                                                    disabled={saving}
+                                                >
+                                                    <option value="">Hesap seçin</option>
+                                                    {accounts.map((acc) => (
+                                                        <option key={acc.id} value={acc.id}>
+                                                            {acc.name} ({acc.currency})
+                                                        </option>
+                                                    ))}
+                                                </Form.Select>
+                                            </Form.Group>
+                                        </Col>
+                                        <Col md={6}>
+                                            <Form.Group controlId="amount">
+                                                <Form.Label>Tutar ({supplierCurrency})</Form.Label>
+                                                <Form.Control
+                                                    type="number"
+                                                    min="0"
+                                                    step="0.01"
+                                                    value={amount}
+                                                    onChange={(event) => setAmount(event.target.value)}
+                                                    placeholder="Ödeme tutarını girin"
+                                                    disabled={saving}
+                                                    required
+                                                />
+                                            </Form.Group>
+                                        </Col>
+                                        <Col md={6}>
+                                            <div className="payment-form-card__converted">
+                                                <div className="small text-uppercase text-muted">Tedarikçi bakiyesine yansıyan</div>
+                                                <div>{formatCurrency(convertedAmountValue, supplierCurrency)}</div>
+                                            </div>
+                                        </Col>
+                                        <Col xs={12}>
+                                            <Form.Group controlId="notes">
+                                                <Form.Label>Açıklama</Form.Label>
+                                                <Form.Control
+                                                    as="textarea"
+                                                    rows={3}
+                                                    value={notes}
+                                                    onChange={(event) => setNotes(event.target.value)}
+                                                    placeholder="İsteğe bağlı açıklama ekleyin"
+                                                    disabled={saving}
+                                                />
+                                            </Form.Group>
+                                        </Col>
+                                    </Row>
+                                    <div className="payment-form-card__note mt-3">
+                                        {transactionType === 'payment'
+                                            ? 'Bu kayıt tedarikçiye yapılan ödeme olarak işlenecek.'
+                                            : 'Bu kayıt tedarikçiden tahsilat olarak işlenecek.'}
+                                    </div>
+                                </Form>
+                            </Card.Body>
+                        </Card>
+                    </Col>
+                    <Col lg={4}>
+                        <Card className="payment-side-card">
+                            <div className="payment-side-card__header">
+                                <div className="payment-side-card__name">{supplierName || 'Tedarikçi'}</div>
+                                <div className="payment-side-card__meta">
+                                    {supplierData?.supplier?.email || 'E-posta bilgisi yok'}
+                                </div>
+                                <div className="payment-side-card__meta">
+                                    {supplierData?.supplier?.phone || 'Telefon bilgisi yok'}
+                                </div>
+                            </div>
+                            <div className="payment-summary">
+                                <div className="payment-summary__item">
+                                    <div className="payment-summary__label">Açık Hesap Bakiyesi</div>
+                                    <div className="payment-summary__value">
+                                        {formatCurrency(summary?.open_balance || 0, supplierCurrency)}
+                                    </div>
+                                    <div className="payment-summary__hint">{describeSupplierBalance(summary?.open_balance)}</div>
+                                </div>
+                                <div className="payment-summary__item">
+                                    <div className="payment-summary__label">Çek / Senet Bakiyesi</div>
+                                    <div className="payment-summary__value">
+                                        {formatCurrency(summary?.check_balance || 0, supplierCurrency)}
+                                    </div>
+                                    <div className="payment-summary__hint">Kayıtlı çek / senet bakiyesi</div>
+                                </div>
+                                <div className="payment-summary__item">
+                                    <div className="payment-summary__label">Adres Bilgileri</div>
+                                    <div className="payment-summary__value">
+                                        {supplierData?.supplier?.address ? supplierData.supplier.address : 'Kayıtlı değil'}
+                                    </div>
+                                    <div className="payment-summary__hint">Adres ve banka bilgilerini tedarikçi profiline ekleyin.</div>
+                                </div>
+                            </div>
+                        </Card>
+                    </Col>
+                </Row>
+            )}
+        </Container>
+    );
+}
+
+export default SupplierPaymentPage;

--- a/frontend/src/styles/payment-page.css
+++ b/frontend/src/styles/payment-page.css
@@ -1,0 +1,194 @@
+.payment-page {
+    background: linear-gradient(135deg, #f5f7fb 0%, #eef2f9 100%);
+    min-height: 100%;
+    padding: 2rem 2.5rem;
+}
+
+.payment-page__header {
+    display: flex;
+    justify-content: flex-end;
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+    flex-wrap: wrap;
+}
+
+.payment-page__header .btn {
+    min-width: 170px;
+    font-weight: 600;
+    border-radius: 10px;
+    box-shadow: 0 6px 16px rgba(15, 23, 42, 0.12);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.payment-page__header .btn:focus,
+.payment-page__header .btn:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 12px 24px rgba(15, 23, 42, 0.18);
+}
+
+.payment-page__save-btn {
+    background: linear-gradient(135deg, #28a745, #2eb85c);
+    border: none;
+}
+
+.payment-page__save-btn:disabled {
+    cursor: not-allowed;
+    opacity: 0.7;
+}
+
+.payment-page__back-btn {
+    background: linear-gradient(135deg, #0d6efd, #17a2b8);
+    border: none;
+}
+
+.payment-form-card,
+.payment-side-card {
+    border: none;
+    border-radius: 16px;
+    overflow: hidden;
+    box-shadow: 0 20px 45px rgba(15, 23, 42, 0.08);
+    background: #ffffff;
+}
+
+.payment-form-card__header {
+    background: linear-gradient(120deg, #0d6efd, #23a6f0);
+    color: #fff;
+    padding: 1.4rem 1.75rem;
+}
+
+.payment-form-card__title {
+    font-size: 1rem;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    margin-bottom: 0.35rem;
+    opacity: 0.85;
+}
+
+.payment-form-card__subtitle {
+    font-size: 1.1rem;
+    font-weight: 600;
+    margin: 0;
+}
+
+.payment-form-card .card-body {
+    padding: 1.75rem;
+}
+
+.payment-form-card .form-label {
+    font-weight: 600;
+    color: #334155;
+}
+
+.payment-form-card .form-control,
+.payment-form-card .form-select {
+    border-radius: 10px;
+    border: 1px solid rgba(15, 23, 42, 0.12);
+    padding: 0.65rem 0.85rem;
+}
+
+.payment-form-card .form-control:focus,
+.payment-form-card .form-select:focus {
+    box-shadow: 0 0 0 0.2rem rgba(13, 110, 253, 0.18);
+    border-color: rgba(13, 110, 253, 0.6);
+}
+
+.payment-form-card__note {
+    font-size: 0.9rem;
+    color: #6b7280;
+}
+
+.payment-form-card__footer {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-top: 1.25rem;
+}
+
+.payment-form-card__converted {
+    padding: 0.85rem 1.1rem;
+    background: rgba(13, 110, 253, 0.1);
+    border-radius: 10px;
+    font-weight: 600;
+    color: #0b5ed7;
+}
+
+.payment-side-card__header {
+    padding: 1.4rem 1.75rem;
+    background: #f7f9fc;
+}
+
+.payment-side-card__name {
+    font-size: 1.5rem;
+    font-weight: 700;
+    margin-bottom: 0.4rem;
+    color: #1f2937;
+}
+
+.payment-side-card__meta {
+    font-size: 0.95rem;
+    color: #6b7280;
+}
+
+.payment-summary {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    padding: 1.5rem 1.75rem 1.75rem;
+}
+
+.payment-summary__item {
+    background: linear-gradient(120deg, rgba(13, 110, 253, 0.08), rgba(23, 162, 184, 0.08));
+    border-radius: 12px;
+    padding: 1rem 1.2rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.payment-summary__label {
+    font-size: 0.85rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: #4b5563;
+}
+
+.payment-summary__value {
+    font-size: 1.15rem;
+    font-weight: 600;
+    color: #0f172a;
+}
+
+.payment-summary__hint {
+    font-size: 0.88rem;
+    color: #64748b;
+}
+
+.payment-page__alert {
+    border-radius: 12px;
+    padding: 0.9rem 1.2rem;
+    margin-bottom: 1.25rem;
+}
+
+@media (max-width: 991.98px) {
+    .payment-page {
+        padding: 1.5rem;
+    }
+
+    .payment-page__header {
+        justify-content: center;
+    }
+}
+
+@media (max-width: 575.98px) {
+    .payment-page__header .btn {
+        width: 100%;
+    }
+
+    .payment-form-card .card-body {
+        padding: 1.25rem;
+    }
+
+    .payment-summary {
+        padding: 1.25rem;
+    }
+}


### PR DESCRIPTION
## Summary
- create new customer and supplier payment pages with collection/payment workflows and account handling
- add shared styling for the payment layout and expose the pages through the router
- update customer and supplier detail actions to navigate to the new payment pages

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68d110d011088323929ccdab33ceeec3