### PR TITLE
Handle exchangerate.host response format and key configuration

### DIFF
--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -160,7 +160,7 @@ EXCHANGE_RATE_API_URL = os.environ.get(
     "https://api.exchangerate.host/latest",
 )
 
-EXCHANGE_RATE_API_KEY = "55ece2e02c8a143ec0cc66f2f4388311"
+EXCHANGE_RATE_API_KEY = os.environ.get("EXCHANGE_RATE_API_KEY")
 
 
 MEDIA_URL = '/media/'


### PR DESCRIPTION
## Summary
- update exchange rate integration to understand exchangerate.host responses and reuse manual or cached rates on failure
- make the API key optional by reading it from the environment and keep using the latest endpoint by default
- extend exchange rate tests to cover the new response format and failure handling paths

## Testing
- python manage.py test api.tests.test_exchange_rates

------
https://chatgpt.com/codex/tasks/task_e_68d2e0bd814c83239e1046bf62293aa1