### PR TITLE
Add live currency conversion for customer payments

### DIFF
--- a/frontend/src/components/CustomerPaymentModal.test.js
+++ b/frontend/src/components/CustomerPaymentModal.test.js
@@ -65,6 +65,14 @@ describe('CustomerPaymentModal', () => {
     const exchangeRateInput = await screen.findByLabelText(/Exchange Rate/i);
     expect(exchangeRateInput).toBeInTheDocument();
 
+    await waitFor(() => {
+      expect(exchangeRateInput).toHaveValue(1.111111);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/Converted Amount/)).toHaveValue('111.11');
+    });
+
     fireEvent.change(exchangeRateInput, { target: { value: '0.9' } });
 
     await waitFor(() => {
@@ -103,8 +111,8 @@ describe('CustomerPaymentModal', () => {
           original_amount: 120,
           original_currency: 'USD',
           account: '2',
-          account_exchange_rate: '0.95',
-          account_converted_amount: 114.00,
+          account_exchange_rate: 0.95,
+          account_converted_amount: 114,
         })
       );
     });

--- a/frontend/src/config/currency.js
+++ b/frontend/src/config/currency.js
@@ -2,6 +2,7 @@ import axiosInstance from '../utils/axiosInstance';
 
 let baseCurrency = 'USD';
 let currencyOptions = [];
+let currencyRates = {};
 
 export const getBaseCurrency = () => baseCurrency;
 
@@ -29,6 +30,12 @@ export const loadCurrencyOptions = async () => {
         const label = name.includes(code) ? name : `${name} (${code})`;
         return [code, label];
       });
+      currencyRates = res.data.reduce((acc, currency) => {
+        if (currency?.code) {
+          acc[currency.code] = Number(currency.exchange_rate) || 0;
+        }
+        return acc;
+      }, {});
     }
   } catch (err) {
     console.error('Failed to fetch currency options', err);
@@ -38,5 +45,37 @@ export const loadCurrencyOptions = async () => {
 
 export const clearCachedCurrencies = () => {
   currencyOptions = [];
+  currencyRates = {};
+};
+
+export const getCurrencyRates = () => currencyRates;
+
+export const loadCurrencyRates = async () => {
+  if (Object.keys(currencyRates).length > 0) {
+    return currencyRates;
+  }
+  try {
+    const res = await axiosInstance.get('/currencies/');
+    if (res.data && Array.isArray(res.data)) {
+      currencyRates = res.data.reduce((acc, currency) => {
+        if (currency?.code) {
+          acc[currency.code] = Number(currency.exchange_rate) || 0;
+        }
+        return acc;
+      }, {});
+
+      if (currencyOptions.length === 0) {
+        currencyOptions = res.data.map((currency) => {
+          const code = currency.code || '';
+          const name = currency.name || code;
+          const label = name.includes(code) ? name : `${name} (${code})`;
+          return [code, label];
+        });
+      }
+    }
+  } catch (err) {
+    console.error('Failed to fetch currency rates', err);
+  }
+  return currencyRates;
 };
 


### PR DESCRIPTION
## Summary
- cache currency exchange rates alongside option labels
- auto populate conversion rates on the customer payment page using live data
- update the customer payment modal to reuse live rates and cover the behaviour with tests

## Testing
- CI=true npm test -- CustomerPaymentModal.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d3b6ca10a483238408ba00822468d2