### PR TITLE
Fix live rate display when account currency differs

### DIFF
--- a/frontend/src/pages/CustomerPaymentPage.js
+++ b/frontend/src/pages/CustomerPaymentPage.js
@@ -150,8 +150,8 @@ function CustomerPaymentPage() {
     };
 
     const requiresExchangeRate = useMemo(
-        () => !account && paymentCurrency && paymentCurrency !== customerCurrency,
-        [account, paymentCurrency, customerCurrency],
+        () => Boolean(paymentCurrency && paymentCurrency !== customerCurrency),
+        [paymentCurrency, customerCurrency],
     );
 
     const convertedAmountValue = useMemo(() => {


### PR DESCRIPTION
## Summary
- ensure the customer payment form still requests an exchange rate whenever the payment currency differs from the customer's currency
- allow the live conversion summary to appear when using a different-currency bank account

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68d3bc5ea80c8323aefb2c868e522f43