### PR TITLE
Display per-currency totals on dashboard summary cards

### DIFF
--- a/frontend/src/pages/DashboardPage.js
+++ b/frontend/src/pages/DashboardPage.js
@@ -34,7 +34,12 @@ const ProgressCard = ({ title, items, headerColor = 'primary', currency = 'USD' 
                 {items.map(({ label, value, variant, breakdown }, idx) => {
                     const percentage = total > 0 ? (Number(value) / total) * 100 : 0;
                     const breakdownEntries = breakdown && Object.entries(breakdown);
-                    const displayValue = formatCurrency(value, currency);
+                    const breakdownDisplay = breakdownEntries && breakdownEntries.length > 0
+                        ? breakdownEntries
+                            .map(([code, amount]) => formatCurrency(amount, code))
+                            .join(', ')
+                        : null;
+                    const displayValue = breakdownDisplay || formatCurrency(value, currency);
                     return (
                         <div key={idx} className="mb-3">
                             <div className="d-flex justify-content-between">

--- a/frontend/src/pages/DashboardPage.test.js
+++ b/frontend/src/pages/DashboardPage.test.js
@@ -47,6 +47,7 @@ describe('DashboardPage currency breakdowns', () => {
 
     const receivablesLabel = await screen.findByText('Receivables');
     const receivablesSection = receivablesLabel.closest('div').parentElement;
+    expect(within(receivablesSection).getByText('$60.00, €200.00')).toBeInTheDocument();
     expect(within(receivablesSection).getByText('USD')).toBeInTheDocument();
     expect(within(receivablesSection).getByText('EUR')).toBeInTheDocument();
 


### PR DESCRIPTION
## Summary
- show comma-separated per-currency totals on dashboard summary cards using each currency's native symbol
- extend the dashboard summary test to assert the rendered per-currency totals

## Testing
- CI=true npm test -- DashboardPage.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d6361e8cc483238f2bceeab6edc40f