### PR TITLE
Enhance sale entry form with searchable product picker

### DIFF
--- a/frontend/src/components/ProductSearchSelect.js
+++ b/frontend/src/components/ProductSearchSelect.js
@@ -1,0 +1,133 @@
+// frontend/src/components/ProductSearchSelect.js
+
+import React, { useEffect, useMemo, useState } from 'react';
+import PropTypes from 'prop-types';
+import { Form, InputGroup, ListGroup, Image } from 'react-bootstrap';
+import { Search } from 'react-bootstrap-icons';
+
+const MAX_RESULTS = 8;
+
+const formatProductLabel = (product) => {
+    if (!product) return '';
+    return product.sku ? `${product.name} · ${product.sku}` : product.name;
+};
+
+function ProductSearchSelect({ products, value, onSelect, placeholder, imageBaseUrl }) {
+    const [query, setQuery] = useState('');
+    const [isFocused, setIsFocused] = useState(false);
+
+    useEffect(() => {
+        if (value) {
+            setQuery(formatProductLabel(value));
+        } else {
+            setQuery('');
+        }
+    }, [value]);
+
+    const filteredProducts = useMemo(() => {
+        const term = query.trim().toLowerCase();
+        if (!term) {
+            return products.slice(0, MAX_RESULTS);
+        }
+        return products
+            .filter((product) => {
+                const name = product.name?.toLowerCase?.() || '';
+                const sku = product.sku?.toLowerCase?.() || '';
+                return name.includes(term) || sku.includes(term);
+            })
+            .slice(0, MAX_RESULTS);
+    }, [products, query]);
+
+    const handleSelect = (product) => {
+        onSelect(product);
+        setQuery(formatProductLabel(product));
+        setIsFocused(false);
+    };
+
+    return (
+        <div className="product-search-select">
+            <InputGroup>
+                <InputGroup.Text>
+                    <Search />
+                </InputGroup.Text>
+                <Form.Control
+                    type="search"
+                    placeholder={placeholder}
+                    value={query}
+                    onChange={(event) => {
+                        setQuery(event.target.value);
+                        setIsFocused(true);
+                    }}
+                    onFocus={() => setIsFocused(true)}
+                    onBlur={() => setTimeout(() => setIsFocused(false), 150)}
+                    aria-label="Search product"
+                />
+            </InputGroup>
+            {isFocused && filteredProducts.length > 0 && (
+                <ListGroup className="product-search-select__results shadow-sm">
+                    {filteredProducts.map((product) => {
+                        const resolvedImage = product.image
+                            ? (product.image.startsWith('http')
+                                ? product.image
+                                : `${imageBaseUrl || ''}${product.image}`)
+                            : null;
+                        return (
+                            <ListGroup.Item
+                                action
+                                key={product.id}
+                                onMouseDown={() => handleSelect(product)}
+                                className="d-flex align-items-center gap-2"
+                            >
+                                {resolvedImage && (
+                                    <Image
+                                        src={resolvedImage}
+                                        alt={product.name}
+                                        thumbnail
+                                        rounded
+                                        width={40}
+                                        height={40}
+                                        onError={(event) => {
+                                            event.target.style.display = 'none';
+                                        }}
+                                    />
+                                )}
+                                <div>
+                                    <div className="fw-semibold">{product.name}</div>
+                                    <div className="text-muted small">{product.sku ? `SKU: ${product.sku}` : 'No SKU'}</div>
+                                </div>
+                            </ListGroup.Item>
+                        );
+                    })}
+                </ListGroup>
+            )}
+        </div>
+    );
+}
+
+ProductSearchSelect.propTypes = {
+    products: PropTypes.arrayOf(
+        PropTypes.shape({
+            id: PropTypes.number.isRequired,
+            name: PropTypes.string.isRequired,
+            sku: PropTypes.string,
+            image: PropTypes.string,
+        })
+    ).isRequired,
+    value: PropTypes.shape({
+        id: PropTypes.number,
+        name: PropTypes.string,
+        sku: PropTypes.string,
+        image: PropTypes.string,
+    }),
+    onSelect: PropTypes.func.isRequired,
+    placeholder: PropTypes.string,
+    imageBaseUrl: PropTypes.string,
+};
+
+ProductSearchSelect.defaultProps = {
+    value: null,
+    placeholder: 'Search product',
+    imageBaseUrl: '',
+};
+
+export default ProductSearchSelect;

--- a/frontend/src/pages/SaleFormPage.js
+++ b/frontend/src/pages/SaleFormPage.js
@@ -1,11 +1,13 @@
 // frontend/src/pages/SaleFormPage.js
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import axiosInstance from '../utils/axiosInstance';
-import { Container, Card, Form, Button, Row, Col, Table, Alert } from 'react-bootstrap';
+import { Container, Card, Form, Button, Row, Col, Table, Alert, Image, Badge } from 'react-bootstrap';
 import { Trash } from 'react-bootstrap-icons';
 import '../styles/datatable.css';
+import '../styles/saleForm.css';
+import ProductSearchSelect from '../components/ProductSearchSelect';
 
 function SaleFormPage() {
     const { customerId, supplierId } = useParams();
@@ -19,7 +21,7 @@ function SaleFormPage() {
     const [allProducts, setAllProducts] = useState([]);
     const [warehouses, setWarehouses] = useState([]);
     const [saleDate, setSaleDate] = useState(new Date().toISOString().slice(0, 10));
-    const [lineItems, setLineItems] = useState([{ product_id: '', quantity: 1, unit_price: 0, warehouse_id: '' }]);
+    const [lineItems, setLineItems] = useState([{ product_id: '', quantity: 1, unit_price: 0, warehouse_id: '', discount: 0 }]);
     
     useEffect(() => {
         // Fetch customer/supplier and all products
@@ -49,16 +51,67 @@ function SaleFormPage() {
         })));
     }, [warehouses]);
 
-    const handleLineItemChange = (index, event) => {
-        const values = [...lineItems];
-        values[index][event.target.name] = event.target.value;
+    const baseApiUrl = useMemo(() => {
+        const apiBase = axiosInstance.defaults.baseURL || '';
+        return apiBase.replace(/\/?api\/?$/, '');
+    }, []);
 
-        // If product changes, update the price
-        if (event.target.name === 'product_id') {
-            const selectedProduct = allProducts.find(p => p.id === parseInt(event.target.value));
-            values[index].unit_price = selectedProduct ? selectedProduct.sale_price : 0;
-        }
-        setLineItems(values);
+    const getProductById = (productId) => {
+        if (!productId) return null;
+        return allProducts.find(p => p.id === Number(productId)) || null;
+    };
+
+    const handleProductSelect = (index, product) => {
+        setLineItems(prev => {
+            const updated = [...prev];
+            const warehouseId = updated[index].warehouse_id || warehouses[0]?.id || '';
+            updated[index] = {
+                ...updated[index],
+                product_id: product?.id || '',
+                unit_price: product ? Number(product.sale_price) : 0,
+                discount: 0,
+                warehouse_id: warehouseId,
+            };
+            return updated;
+        });
+    };
+
+    const handleLineItemChange = (index, event) => {
+        const { name } = event.target;
+        let { value } = event.target;
+        setLineItems(prev => {
+            const values = [...prev];
+            const current = { ...values[index] };
+
+            if (name === 'quantity' || name === 'unit_price' || name === 'discount') {
+                value = Number(value);
+            }
+
+            if (name === 'discount') {
+                const boundedDiscount = Math.min(Math.max(value || 0, 0), 100);
+                current.discount = boundedDiscount;
+                const selectedProduct = getProductById(current.product_id);
+                if (selectedProduct) {
+                    const basePrice = Number(selectedProduct.sale_price) || 0;
+                    current.unit_price = Number((basePrice * (1 - boundedDiscount / 100)).toFixed(2));
+                }
+            } else if (name === 'unit_price') {
+                current.unit_price = value || 0;
+                current.discount = 0;
+            } else if (name === 'quantity') {
+                current.quantity = value ? Math.max(value, 0) : 0;
+            } else if (name === 'warehouse_id') {
+                current.warehouse_id = value;
+            } else if (name === 'product_id') {
+                current.product_id = value;
+                const selectedProduct = getProductById(value);
+                current.unit_price = selectedProduct ? Number(selectedProduct.sale_price) : 0;
+                current.discount = 0;
+            }
+
+            values[index] = current;
+            return values;
+        });
     };
 
     const handleAddItem = () => {
@@ -69,6 +122,7 @@ function SaleFormPage() {
                 quantity: 1,
                 unit_price: 0,
                 warehouse_id: warehouses[0]?.id || '',
+                discount: 0,
             },
         ]);
     };
@@ -80,7 +134,7 @@ function SaleFormPage() {
     };
 
     const calculateTotal = () => {
-        return lineItems.reduce((total, item) => total + (item.quantity * item.unit_price), 0);
+        return lineItems.reduce((total, item) => total + (Number(item.quantity) * Number(item.unit_price || 0)), 0);
     };
 
     const handleSubmit = async (e) => {
@@ -127,6 +181,13 @@ function SaleFormPage() {
 
     const hasWarehouses = warehouses.length > 0;
 
+    const formatCurrency = (amount) => {
+        return new Intl.NumberFormat('en-US', {
+            style: 'currency',
+            currency: customer.currency,
+        }).format(amount || 0);
+    };
+
     return (
         <Container>
             <Card>
@@ -155,80 +216,128 @@ function SaleFormPage() {
                                         <th>Product</th>
                                         <th>Quantity</th>
                                         <th>Warehouse</th>
+                                        <th>Stock Remaining</th>
+                                        <th>Discount (%)</th>
                                         <th>Unit Price</th>
                                         <th>Line Total</th>
                                         <th>Actions</th>
                                     </tr>
                                 </thead>
                                 <tbody>
-                                    {lineItems.map((item, index) => (
-                                        <tr key={index}>
-                                            <td>
-                                                <Form.Select
-                                                    name="product_id"
-                                                    value={item.product_id}
-                                                    onChange={(e) => handleLineItemChange(index, e)}
-                                                >
-                                                    <option>Select Product</option>
-                                                    {allProducts.map((product) => (
-                                                        <option key={product.id} value={product.id}>
-                                                            {product.name}
-                                                        </option>
-                                                    ))}
-                                                </Form.Select>
-                                            </td>
-                                            <td>
-                                                <Form.Control
-                                                    type="number"
-                                                    name="quantity"
-                                                    value={item.quantity}
-                                                    onChange={(e) => handleLineItemChange(index, e)}
-                                                />
-                                            </td>
-                                            <td>
-                                                <Form.Select
-                                                    name="warehouse_id"
-                                                    value={item.warehouse_id}
-                                                    onChange={(e) => handleLineItemChange(index, e)}
-                                                    disabled={!hasWarehouses}
-                                                >
-                                                    <option value="">Select Warehouse</option>
-                                                    {warehouses.map((warehouse) => (
-                                                        <option key={warehouse.id} value={warehouse.id}>
-                                                            {warehouse.name}
-                                                        </option>
-                                                    ))}
-                                                </Form.Select>
-                                            </td>
-                                            <td>
-                                                <Form.Control
-                                                    type="number"
-                                                    step="0.01"
-                                                    name="unit_price"
-                                                    value={item.unit_price}
-                                                    onChange={(e) => handleLineItemChange(index, e)}
-                                                />
-                                            </td>
-                                            <td>
-                                                {new Intl.NumberFormat('en-US', {
-                                                    style: 'currency',
-                                                    currency: customer.currency,
-                                                }).format(item.quantity * item.unit_price)}
-                                            </td>
-                                            <td>
-                                                <Button variant="danger" onClick={() => handleRemoveItem(index)}>
-                                                    <Trash />
-                                                </Button>
-                                            </td>
-                                        </tr>
-                                    ))}
+                                    {lineItems.map((item, index) => {
+                                        const selectedProduct = getProductById(item.product_id);
+                                        const warehouseQuantity = selectedProduct?.warehouse_quantities?.find(
+                                            (stock) => stock.warehouse_id === Number(item.warehouse_id)
+                                        );
+                                        const stockRemaining = warehouseQuantity ? Number(warehouseQuantity.quantity) : null;
+                                        const productImage = selectedProduct?.image
+                                            ? (selectedProduct.image.startsWith('http')
+                                                ? selectedProduct.image
+                                                : `${baseApiUrl}${selectedProduct.image}`)
+                                            : null;
+
+                                        return (
+                                            <tr key={index}>
+                                                <td>
+                                                    <div className="d-flex align-items-start gap-3">
+                                                        <div className="sale-form__product-thumb">
+                                                            {productImage ? (
+                                                                <Image src={productImage} rounded thumbnail alt={selectedProduct?.name || 'Product preview'} />
+                                                            ) : (
+                                                                <div className="sale-form__product-placeholder">No Image</div>
+                                                            )}
+                                                        </div>
+                                                        <div className="flex-grow-1">
+                                                            <ProductSearchSelect
+                                                                products={allProducts}
+                                                                value={selectedProduct}
+                                                                onSelect={(product) => handleProductSelect(index, product)}
+                                                                placeholder="Search name or SKU"
+                                                                imageBaseUrl={baseApiUrl}
+                                                            />
+                                                            {selectedProduct && (
+                                                                <div className="mt-2 small text-muted">
+                                                                    <div>{selectedProduct.sku ? `SKU: ${selectedProduct.sku}` : 'No SKU assigned'}</div>
+                                                                    <div>Base price: {formatCurrency(Number(selectedProduct.sale_price))}</div>
+                                                                </div>
+                                                            )}
+                                                        </div>
+                                                    </div>
+                                                </td>
+                                                <td>
+                                                    <Form.Control
+                                                        type="number"
+                                                        name="quantity"
+                                                        min="0"
+                                                        step="0.01"
+                                                        value={item.quantity}
+                                                        onChange={(e) => handleLineItemChange(index, e)}
+                                                    />
+                                                </td>
+                                                <td>
+                                                    <Form.Select
+                                                        name="warehouse_id"
+                                                        value={item.warehouse_id}
+                                                        onChange={(e) => handleLineItemChange(index, e)}
+                                                        disabled={!hasWarehouses}
+                                                    >
+                                                        <option value="">Select Warehouse</option>
+                                                        {warehouses.map((warehouse) => (
+                                                            <option key={warehouse.id} value={warehouse.id}>
+                                                                {warehouse.name}
+                                                            </option>
+                                                        ))}
+                                                    </Form.Select>
+                                                </td>
+                                                <td className="align-middle">
+                                                    {selectedProduct ? (
+                                                        <Badge bg={stockRemaining && stockRemaining > 0 ? 'success' : 'danger'}>
+                                                            {stockRemaining !== null ? `${stockRemaining} available` : 'No data'}
+                                                        </Badge>
+                                                    ) : (
+                                                        <span className="text-muted">Select a product</span>
+                                                    )}
+                                                </td>
+                                                <td>
+                                                    <Form.Control
+                                                        type="number"
+                                                        name="discount"
+                                                        min="0"
+                                                        max="100"
+                                                        step="0.1"
+                                                        value={item.discount}
+                                                        onChange={(e) => handleLineItemChange(index, e)}
+                                                        placeholder="0"
+                                                        disabled={!selectedProduct}
+                                                    />
+                                                </td>
+                                                <td>
+                                                    <Form.Control
+                                                        type="number"
+                                                        step="0.01"
+                                                        name="unit_price"
+                                                        value={item.unit_price}
+                                                        onChange={(e) => handleLineItemChange(index, e)}
+                                                        disabled={!selectedProduct}
+                                                    />
+                                                    <Form.Text muted>Final unit price</Form.Text>
+                                                </td>
+                                                <td className="fw-semibold align-middle">{formatCurrency(Number(item.quantity) * Number(item.unit_price || 0))}</td>
+                                                <td className="text-center">
+                                                    <Button variant="danger" onClick={() => handleRemoveItem(index)}>
+                                                        <Trash />
+                                                    </Button>
+                                                </td>
+                                            </tr>
+                                        );
+                                    })}
                                 </tbody>
                             </Table>
                         </div>
                         <Button variant="secondary" onClick={handleAddItem} disabled={!hasWarehouses}>+ Add Item</Button>
 
                         <div className="d-flex justify-content-end mt-3">
-                            <h3>Total: {new Intl.NumberFormat('en-US', { style: 'currency', currency: customer.currency }).format(calculateTotal())}</h3>
+                            <h3>Total: {formatCurrency(calculateTotal())}</h3>
                         </div>
                         
                         <div className="mt-4">

--- a/frontend/src/styles/saleForm.css
+++ b/frontend/src/styles/saleForm.css
@@ -1,0 +1,49 @@
+/* frontend/src/styles/saleForm.css */
+
+.product-search-select {
+    position: relative;
+}
+
+.product-search-select__results {
+    position: absolute;
+    z-index: 1000;
+    width: 100%;
+    max-height: 260px;
+    overflow-y: auto;
+    margin-top: 0.25rem;
+}
+
+.sale-form__product-thumb {
+    width: 72px;
+    height: 72px;
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: #f1f3f5;
+    border: 1px dashed #ced4da;
+    border-radius: 0.5rem;
+    overflow: hidden;
+    font-size: 0.75rem;
+    color: #6c757d;
+    text-align: center;
+    padding: 0.25rem;
+}
+
+.sale-form__product-thumb img,
+.sale-form__product-thumb .img-thumbnail {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.sale-form__product-placeholder {
+    padding: 0.25rem;
+}
+
+@media (max-width: 768px) {
+    .sale-form__product-thumb {
+        width: 56px;
+        height: 56px;
+    }
+}


### PR DESCRIPTION
## Summary
- replace the basic product dropdown with a searchable selector that supports SKU lookups and previews the product image
- add per-line discount handling with automatic price recalculation and display the remaining warehouse stock for the chosen item
- introduce supporting styling for the new selector layout and product thumbnail presentation

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68d63d0bad2483238860701b53e4b98e