### PR TITLE
Revamp sale creation UI with modal workflow

### DIFF
--- a/frontend/src/components/SaleItemModal.js
+++ b/frontend/src/components/SaleItemModal.js
@@ -1,0 +1,298 @@
+// frontend/src/components/SaleItemModal.js
+
+import React, { useEffect, useMemo, useState } from 'react';
+import PropTypes from 'prop-types';
+import { Alert, Badge, Button, Form, Modal, Row, Col, Stack } from 'react-bootstrap';
+import ProductSearchSelect from './ProductSearchSelect';
+
+function SaleItemModal({ show, onHide, onSave, initialItem, products, warehouses, currency, imageBaseUrl }) {
+    const [formState, setFormState] = useState({
+        product_id: '',
+        quantity: 1,
+        unit_price: 0,
+        warehouse_id: '',
+        discount: 0,
+        note: '',
+    });
+
+    useEffect(() => {
+        if (!show) return;
+        const defaultWarehouse = warehouses[0]?.id || '';
+        setFormState({
+            product_id: initialItem?.product_id || '',
+            quantity: initialItem?.quantity ?? 1,
+            unit_price: initialItem?.unit_price ?? 0,
+            warehouse_id: initialItem?.warehouse_id || defaultWarehouse,
+            discount: initialItem?.discount ?? 0,
+            note: initialItem?.note || '',
+        });
+    }, [show, initialItem, warehouses]);
+
+    const selectedProduct = useMemo(() => {
+        if (!formState.product_id) return null;
+        return products.find((product) => product.id === Number(formState.product_id)) || null;
+    }, [formState.product_id, products]);
+
+    const defaultCurrencyFormatter = useMemo(() => {
+        return new Intl.NumberFormat('en-US', { style: 'currency', currency });
+    }, [currency]);
+
+    const handleProductSelect = (product) => {
+        if (!product) {
+            setFormState((prev) => ({
+                ...prev,
+                product_id: '',
+                unit_price: 0,
+                discount: 0,
+            }));
+            return;
+        }
+        const defaultWarehouse = formState.warehouse_id || warehouses[0]?.id || '';
+        setFormState((prev) => ({
+            ...prev,
+            product_id: product.id,
+            quantity: prev.quantity || 1,
+            unit_price: Number(product.sale_price) || 0,
+            discount: 0,
+            warehouse_id: defaultWarehouse,
+        }));
+    };
+
+    const handleDiscountChange = (value) => {
+        const bounded = Math.min(Math.max(Number(value) || 0, 0), 100);
+        if (!selectedProduct) {
+            setFormState((prev) => ({ ...prev, discount: bounded }));
+            return;
+        }
+        const basePrice = Number(selectedProduct.sale_price) || 0;
+        const discountedPrice = Number((basePrice * (1 - bounded / 100)).toFixed(2));
+        setFormState((prev) => ({
+            ...prev,
+            discount: bounded,
+            unit_price: discountedPrice,
+        }));
+    };
+
+    const handleUnitPriceChange = (value) => {
+        const price = Number(value) || 0;
+        setFormState((prev) => ({
+            ...prev,
+            unit_price: price,
+            discount: 0,
+        }));
+    };
+
+    const handleFieldChange = (name, value) => {
+        setFormState((prev) => ({
+            ...prev,
+            [name]: value,
+        }));
+    };
+
+    const lineTotal = Number(formState.quantity || 0) * Number(formState.unit_price || 0);
+    const stockInfo = selectedProduct?.warehouse_quantities?.find(
+        (stock) => stock.warehouse_id === Number(formState.warehouse_id)
+    );
+    const availableStock = stockInfo ? Number(stockInfo.quantity) : null;
+
+    const resolvedImage = selectedProduct?.image
+        ? selectedProduct.image.startsWith('http')
+            ? selectedProduct.image
+            : `${imageBaseUrl}${selectedProduct.image}`
+        : null;
+
+    const canSave = Boolean(
+        formState.product_id &&
+        Number(formState.quantity) > 0 &&
+        Number(formState.unit_price) >= 0 &&
+        (formState.warehouse_id || warehouses.length === 0)
+    );
+
+    const handleSave = () => {
+        if (!canSave) return;
+        onSave({
+            ...formState,
+            quantity: Number(formState.quantity),
+            unit_price: Number(formState.unit_price),
+            discount: Number(formState.discount) || 0,
+        });
+    };
+
+    return (
+        <Modal show={show} onHide={onHide} centered size="lg" className="sale-form__modal">
+            <Modal.Header closeButton>
+                <Modal.Title>{formState.product_id ? 'Edit item' : 'Add item'}</Modal.Title>
+            </Modal.Header>
+            <Modal.Body>
+                <Stack gap={4}>
+                    <div className="sale-form__modal-product">
+                        <div className="sale-form__modal-image">
+                            {resolvedImage ? (
+                                <img src={resolvedImage} alt={selectedProduct?.name || 'Product preview'} />
+                            ) : (
+                                <span>No image</span>
+                            )}
+                        </div>
+                        <div className="sale-form__modal-info">
+                            <h5>{selectedProduct?.name || 'Select a product'}</h5>
+                            <div className="sale-form__modal-meta">
+                                {selectedProduct?.sku && <span>SKU: {selectedProduct.sku}</span>}
+                                {selectedProduct?.sale_price && (
+                                    <span>Base: {defaultCurrencyFormatter.format(Number(selectedProduct.sale_price))}</span>
+                                )}
+                                {availableStock !== null && (
+                                    <span>
+                                        Stock: <Badge bg={availableStock > 0 ? 'success' : 'danger'}>{availableStock}</Badge>
+                                    </span>
+                                )}
+                            </div>
+                            <ProductSearchSelect
+                                products={products}
+                                value={selectedProduct}
+                                onSelect={handleProductSelect}
+                                placeholder="Search name or SKU"
+                                imageBaseUrl={imageBaseUrl}
+                            />
+                        </div>
+                    </div>
+                    <Row className="gy-3">
+                        <Col md={4}>
+                            <Form.Group controlId="itemQuantity">
+                                <Form.Label>Quantity</Form.Label>
+                                <Form.Control
+                                    type="number"
+                                    min="0"
+                                    step="0.01"
+                                    value={formState.quantity}
+                                    onChange={(event) => handleFieldChange('quantity', event.target.value)}
+                                />
+                            </Form.Group>
+                        </Col>
+                        <Col md={4}>
+                            <Form.Group controlId="itemWarehouse">
+                                <Form.Label>Warehouse</Form.Label>
+                                <Form.Select
+                                    value={formState.warehouse_id}
+                                    onChange={(event) => handleFieldChange('warehouse_id', event.target.value)}
+                                    disabled={warehouses.length === 0}
+                                >
+                                    <option value="">Select warehouse</option>
+                                    {warehouses.map((warehouse) => (
+                                        <option key={warehouse.id} value={warehouse.id}>
+                                            {warehouse.name}
+                                        </option>
+                                    ))}
+                                </Form.Select>
+                            </Form.Group>
+                        </Col>
+                        <Col md={4}>
+                            <Form.Group controlId="itemDiscount">
+                                <Form.Label>Discount %</Form.Label>
+                                <Form.Control
+                                    type="number"
+                                    min="0"
+                                    max="100"
+                                    step="0.1"
+                                    value={formState.discount}
+                                    onChange={(event) => handleDiscountChange(event.target.value)}
+                                    disabled={!selectedProduct}
+                                />
+                            </Form.Group>
+                        </Col>
+                        <Col md={6}>
+                            <Form.Group controlId="itemUnitPrice">
+                                <Form.Label>Unit Price</Form.Label>
+                                <Form.Control
+                                    type="number"
+                                    step="0.01"
+                                    value={formState.unit_price}
+                                    onChange={(event) => handleUnitPriceChange(event.target.value)}
+                                    disabled={!selectedProduct}
+                                />
+                                <Form.Text muted>Currency: {currency}</Form.Text>
+                            </Form.Group>
+                        </Col>
+                        <Col md={6}>
+                            <Form.Group controlId="itemNote">
+                                <Form.Label>Note</Form.Label>
+                                <Form.Control
+                                    type="text"
+                                    value={formState.note}
+                                    onChange={(event) => handleFieldChange('note', event.target.value)}
+                                    placeholder="Optional item note"
+                                />
+                            </Form.Group>
+                        </Col>
+                    </Row>
+                    <div className="sale-form__modal-summary">
+                        <div>
+                            <span className="sale-form__modal-summary-label">Line total</span>
+                            <span className="sale-form__modal-summary-value">{defaultCurrencyFormatter.format(lineTotal)}</span>
+                        </div>
+                        <div>
+                            <span className="sale-form__modal-summary-label">Discount</span>
+                            <span className="sale-form__modal-summary-value">{`${Number(formState.discount || 0).toFixed(2)}%`}</span>
+                        </div>
+                    </div>
+                    {!warehouses.length && (
+                        <Alert variant="warning" className="mb-0">
+                            No warehouses available. Please create a warehouse before saving items.
+                        </Alert>
+                    )}
+                </Stack>
+            </Modal.Body>
+            <Modal.Footer>
+                <Button variant="outline-secondary" onClick={onHide}>
+                    Cancel
+                </Button>
+                <Button variant="success" onClick={handleSave} disabled={!canSave}>
+                    {formState.product_id ? 'Save item' : 'Add item'}
+                </Button>
+            </Modal.Footer>
+        </Modal>
+    );
+}
+
+SaleItemModal.propTypes = {
+    show: PropTypes.bool.isRequired,
+    onHide: PropTypes.func.isRequired,
+    onSave: PropTypes.func.isRequired,
+    initialItem: PropTypes.shape({
+        product_id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+        quantity: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+        unit_price: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+        warehouse_id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+        discount: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+        note: PropTypes.string,
+    }),
+    products: PropTypes.arrayOf(
+        PropTypes.shape({
+            id: PropTypes.number.isRequired,
+            name: PropTypes.string.isRequired,
+            sku: PropTypes.string,
+            sale_price: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+            image: PropTypes.string,
+            warehouse_quantities: PropTypes.arrayOf(
+                PropTypes.shape({
+                    warehouse_id: PropTypes.number.isRequired,
+                    quantity: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+                })
+            ),
+        })
+    ).isRequired,
+    warehouses: PropTypes.arrayOf(
+        PropTypes.shape({
+            id: PropTypes.number.isRequired,
+            name: PropTypes.string.isRequired,
+        })
+    ).isRequired,
+    currency: PropTypes.string.isRequired,
+    imageBaseUrl: PropTypes.string,
+};
+
+SaleItemModal.defaultProps = {
+    initialItem: null,
+    imageBaseUrl: '',
+};
+
+export default SaleItemModal;

--- a/frontend/src/styles/saleForm.css
+++ b/frontend/src/styles/saleForm.css
@@ -189,3 +189,294 @@
         height: 56px;
     }
 }
+
+/* New layout inspired by Bizim Hesap */
+
+.sale-form__container {
+    padding-top: 1rem;
+    padding-bottom: 2rem;
+}
+
+.sale-form__layout {
+    row-gap: 1.5rem;
+}
+
+.sale-form__sidebar-card {
+    border: none;
+    border-radius: 1.25rem;
+    overflow: hidden;
+    box-shadow: 0 20px 60px -32px rgba(15, 23, 42, 0.45);
+    background: #f3f7ff;
+}
+
+.sale-form__sidebar-card .card-header {
+    background: linear-gradient(135deg, #3a7bd5 0%, #3a6073 100%);
+    color: #fff;
+    padding: 1.5rem;
+}
+
+.sale-form__sidebar-title {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.sale-form__sidebar-label {
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    opacity: 0.85;
+}
+
+.sale-form__sidebar-entity {
+    font-size: 1.35rem;
+    font-weight: 600;
+}
+
+.sale-form__sidebar-card .card-body {
+    padding: 1.5rem;
+}
+
+.sale-form__entity-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    font-size: 0.85rem;
+    color: #46618a;
+}
+
+.sale-form__summary {
+    background: #fff;
+    border-radius: 1rem;
+    padding: 1.25rem;
+    box-shadow: inset 0 0 0 1px rgba(58, 123, 213, 0.08);
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.sale-form__summary-row {
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.95rem;
+    color: #334155;
+}
+
+.sale-form__summary-row--strong {
+    font-weight: 700;
+    font-size: 1.05rem;
+}
+
+.sale-form__sidebar-card .card-footer {
+    background: transparent;
+    border-top: none;
+    padding: 1.5rem;
+}
+
+.sale-form__items-card {
+    border: none;
+    border-radius: 1.25rem;
+    box-shadow: 0 30px 60px -40px rgba(15, 23, 42, 0.5);
+}
+
+.sale-form__items-card .card-header {
+    padding: 1.5rem;
+    background: #fff;
+    border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.sale-form__items-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+}
+
+.sale-form__quick-add {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+.sale-form__items-card .card-body {
+    padding: 1.5rem;
+    background: linear-gradient(180deg, #f8fbff 0%, #eef3fb 100%);
+}
+
+.sale-items-table {
+    border-collapse: separate;
+    border-spacing: 0 0.75rem;
+}
+
+.sale-items-table thead th {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: #64748b;
+    border-bottom: none;
+    padding-bottom: 0.75rem;
+}
+
+.sale-items-table tbody tr {
+    background: #fff;
+    box-shadow: 0 18px 36px -28px rgba(30, 64, 175, 0.45);
+    border-radius: 1rem;
+}
+
+.sale-items-table tbody tr td {
+    padding: 1rem 1.25rem;
+    vertical-align: middle;
+}
+
+.sale-items-table tbody tr td:first-child {
+    border-top-left-radius: 1rem;
+    border-bottom-left-radius: 1rem;
+}
+
+.sale-items-table tbody tr td:last-child {
+    border-top-right-radius: 1rem;
+    border-bottom-right-radius: 1rem;
+}
+
+.sale-items-table__product {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.sale-items-table__name {
+    font-weight: 600;
+    color: #1e293b;
+}
+
+.sale-items-table__meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    font-size: 0.8rem;
+    color: #64748b;
+}
+
+.sale-items-table__meta span::before {
+    content: '';
+    display: inline-block;
+    width: 4px;
+    height: 4px;
+    border-radius: 50%;
+    background: currentColor;
+    margin-right: 0.35rem;
+}
+
+.sale-items-table__meta span:first-child::before {
+    display: none;
+}
+
+.sale-items-table__actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5rem;
+}
+
+.sale-form__modal .modal-content {
+    border-radius: 1.25rem;
+    border: none;
+    box-shadow: 0 28px 60px -32px rgba(15, 23, 42, 0.45);
+}
+
+.sale-form__modal-product {
+    display: flex;
+    gap: 1.5rem;
+    align-items: flex-start;
+}
+
+.sale-form__modal-image {
+    width: 96px;
+    height: 96px;
+    border-radius: 1rem;
+    background: #edf2ff;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+    color: #64748b;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.sale-form__modal-image img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.sale-form__modal-info {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.sale-form__modal-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    font-size: 0.85rem;
+    color: #64748b;
+}
+
+.sale-form__modal-summary {
+    display: flex;
+    justify-content: flex-end;
+    gap: 2rem;
+    font-weight: 600;
+    color: #1e293b;
+}
+
+.sale-form__modal-summary-label {
+    display: block;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: #64748b;
+}
+
+.sale-form__modal-summary-value {
+    font-size: 1.1rem;
+}
+
+@media (max-width: 992px) {
+    .sale-form__items-header {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .sale-form__quick-add {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .sale-items-table tbody tr td {
+        padding: 0.75rem 1rem;
+    }
+}
+
+@media (max-width: 576px) {
+    .sale-form__modal-product {
+        flex-direction: column;
+        align-items: center;
+        text-align: center;
+    }
+
+    .sale-form__modal-info {
+        align-items: center;
+    }
+
+    .sale-form__modal-summary {
+        flex-direction: column;
+        align-items: center;
+        gap: 1rem;
+    }
+}


### PR DESCRIPTION
## Summary
- restyled the sale creation page with a two-column layout, order metadata controls, and a product table that mirrors the Bizim Hesap flow
- introduced a reusable sale item modal to manage product selection, pricing, discounts, and stock indicators
- added dedicated styles for the refreshed layout, table presentation, and modal experience

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68d6cba81398832382144af478392bcc