### PR TITLE
Support supplier transaction modes in sale form

### DIFF
--- a/frontend/src/components/SaleItemModal.js
+++ b/frontend/src/components/SaleItemModal.js
@@ -5,7 +5,17 @@ import PropTypes from 'prop-types';
 import { Alert, Badge, Button, Form, Modal, Row, Col, Stack } from 'react-bootstrap';
 import ProductSearchSelect from './ProductSearchSelect';
 
-function SaleItemModal({ show, onHide, onSave, initialItem, products, warehouses, currency, imageBaseUrl }) {
+function SaleItemModal({
+    show,
+    onHide,
+    onSave,
+    initialItem,
+    products,
+    warehouses,
+    currency,
+    imageBaseUrl,
+    priceField,
+}) {
     const [formState, setFormState] = useState({
         product_id: '',
         quantity: 1,
@@ -52,7 +62,7 @@ function SaleItemModal({ show, onHide, onSave, initialItem, products, warehouses
             ...prev,
             product_id: product.id,
             quantity: prev.quantity || 1,
-            unit_price: Number(product.sale_price) || 0,
+            unit_price: Number(product[priceField]) || 0,
             discount: 0,
             warehouse_id: defaultWarehouse,
         }));
@@ -64,7 +74,7 @@ function SaleItemModal({ show, onHide, onSave, initialItem, products, warehouses
             setFormState((prev) => ({ ...prev, discount: bounded }));
             return;
         }
-        const basePrice = Number(selectedProduct.sale_price) || 0;
+        const basePrice = Number(selectedProduct?.[priceField]) || 0;
         const discountedPrice = Number((basePrice * (1 - bounded / 100)).toFixed(2));
         setFormState((prev) => ({
             ...prev,
@@ -137,8 +147,11 @@ function SaleItemModal({ show, onHide, onSave, initialItem, products, warehouses
                             <h5>{selectedProduct?.name || 'Select a product'}</h5>
                             <div className="sale-form__modal-meta">
                                 {selectedProduct?.sku && <span>SKU: {selectedProduct.sku}</span>}
-                                {selectedProduct?.sale_price && (
-                                    <span>Base: {defaultCurrencyFormatter.format(Number(selectedProduct.sale_price))}</span>
+                                {selectedProduct?.[priceField] && (
+                                    <span>
+                                        Base:{' '}
+                                        {defaultCurrencyFormatter.format(Number(selectedProduct?.[priceField]))}
+                                    </span>
                                 )}
                                 {availableStock !== null && (
                                     <span>
@@ -195,8 +208,11 @@ function SaleItemModal({ show, onHide, onSave, initialItem, products, warehouses
                                     step="0.1"
                                     value={formState.discount}
                                     onChange={(event) => handleDiscountChange(event.target.value)}
-                                    disabled={!selectedProduct}
+                                    disabled={!selectedProduct || priceField !== 'sale_price'}
                                 />
+                                {priceField !== 'sale_price' && (
+                                    <Form.Text muted>Discounts are not applied on supplier purchases.</Form.Text>
+                                )}
                             </Form.Group>
                         </Col>
                         <Col md={6}>
@@ -271,6 +287,7 @@ SaleItemModal.propTypes = {
             name: PropTypes.string.isRequired,
             sku: PropTypes.string,
             sale_price: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+            purchase_price: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
             image: PropTypes.string,
             warehouse_quantities: PropTypes.arrayOf(
                 PropTypes.shape({
@@ -288,11 +305,13 @@ SaleItemModal.propTypes = {
     ).isRequired,
     currency: PropTypes.string.isRequired,
     imageBaseUrl: PropTypes.string,
+    priceField: PropTypes.oneOf(['sale_price', 'purchase_price']),
 };
 
 SaleItemModal.defaultProps = {
     initialItem: null,
     imageBaseUrl: '',
+    priceField: 'sale_price',
 };
 
 export default SaleItemModal;

--- a/frontend/src/pages/SaleFormPage.js
+++ b/frontend/src/pages/SaleFormPage.js
@@ -31,6 +31,7 @@ function SaleFormPage() {
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [itemModalState, setItemModalState] = useState({ show: false, index: null, initialItem: null });
     const [quickSearchKey, setQuickSearchKey] = useState(0);
+    const [supplierTransactionType, setSupplierTransactionType] = useState('sell');
 
     useEffect(() => {
         const fetchData = async () => {
@@ -61,21 +62,54 @@ function SaleFormPage() {
         );
     }, [warehouses]);
 
+    useEffect(() => {
+        if (!isSupplierSale) {
+            setSupplierTransactionType('sell');
+        }
+    }, [isSupplierSale]);
+
     const baseApiUrl = useMemo(() => {
         const apiBase = axiosInstance.defaults.baseURL || '';
         return apiBase.replace(/\/?api\/?$/, '');
     }, []);
+
+    const priceField = isSupplierSale && supplierTransactionType === 'buy' ? 'purchase_price' : 'sale_price';
+    const allowDiscounts = priceField === 'sale_price';
 
     const getProductById = useCallback((productId) => {
         if (!productId) return null;
         return allProducts.find((p) => p.id === Number(productId)) || null;
     }, [allProducts]);
 
+    useEffect(() => {
+        if (!isSupplierSale) return;
+        setLineItems((prev) =>
+            prev.map((item) => {
+                if (!item.product_id) return item;
+                const product = allProducts.find((product) => product.id === Number(item.product_id));
+                if (!product) return item;
+                const updated = {
+                    ...item,
+                    unit_price: Number(product[priceField]) || 0,
+                };
+                if (!allowDiscounts) {
+                    updated.discount = 0;
+                }
+                return updated;
+            })
+        );
+    }, [allProducts, allowDiscounts, isSupplierSale, priceField]);
+
+    const handleSupplierModeChange = (mode) => {
+        if (mode === supplierTransactionType) return;
+        setSupplierTransactionType(mode);
+    };
+
     const openCreateItemModal = (product = null) => {
         const defaultItem = {
             product_id: product?.id || '',
             quantity: product ? 1 : 1,
-            unit_price: product ? Number(product.sale_price) : 0,
+            unit_price: product ? Number(product[priceField]) || 0 : 0,
             warehouse_id: warehouses[0]?.id || '',
             discount: 0,
             note: '',
@@ -97,7 +131,7 @@ function SaleFormPage() {
             quantity: Number(item.quantity),
             unit_price: Number(item.unit_price),
             warehouse_id: item.warehouse_id ? Number(item.warehouse_id) : warehouses[0]?.id || '',
-            discount: Number(item.discount) || 0,
+            discount: allowDiscounts ? Number(item.discount) || 0 : 0,
             note: item.note || '',
         };
         setLineItems((prev) => {
@@ -130,11 +164,11 @@ function SaleFormPage() {
                     return acc;
                 }
                 const product = getProductById(item.product_id);
-                const basePrice = Number(product?.sale_price) || Number(item.unit_price) || 0;
+                const basePrice = Number(product?.[priceField]) || Number(item.unit_price) || 0;
                 const quantity = Number(item.quantity) || 0;
                 const lineBase = basePrice * quantity;
                 const lineNet = Number(item.unit_price || 0) * quantity;
-                const lineDiscount = lineBase - lineNet;
+                const lineDiscount = allowDiscounts ? lineBase - lineNet : 0;
 
                 return {
                     base: acc.base + lineBase,
@@ -144,9 +178,23 @@ function SaleFormPage() {
             },
             { base: 0, discount: 0, net: 0 }
         );
-    }, [getProductById, lineItems]);
+    }, [allowDiscounts, getProductById, lineItems, priceField]);
 
-    const hasLineItems = lineItems.length > 0;
+    const hasLineItems = lineItems.some((item) => item.product_id);
+
+    const transactionKind = isSupplierSale
+        ? supplierTransactionType === 'buy'
+            ? 'purchase'
+            : 'sale'
+        : isOffer
+        ? 'offer'
+        : 'sale';
+    const transactionLabelMap = { sale: 'Sale', offer: 'Offer', purchase: 'Purchase' };
+    const transactionLabel = transactionLabelMap[transactionKind];
+    const saleDateLabel = transactionKind === 'offer' ? 'Offer Date' : transactionKind === 'purchase' ? 'Purchase Date' : 'Sale Date';
+    const invoiceDateLabel = transactionKind === 'purchase' ? 'Bill Date' : 'Invoice Date';
+    const invoiceNumberLabel = transactionKind === 'purchase' ? 'Bill No' : 'Invoice No';
+    const submitLabel = transactionKind === 'offer' ? 'Save Offer' : transactionKind === 'purchase' ? 'Save Purchase' : 'Save Sale';
 
     const handleSubmit = async (event) => {
         event.preventDefault();
@@ -160,25 +208,37 @@ function SaleFormPage() {
                     quantity: Number(item.quantity),
                     unit_price: Number(item.unit_price),
                 };
-                if (!isOffer) {
+                if (transactionKind !== 'offer') {
                     base.warehouse_id = Number(item.warehouse_id);
                 }
                 return base;
             });
 
         if (payloadItems.length === 0) {
-            setFormError('Add at least one product before saving.');
+            setFormError('Add at least one product before saving this transaction.');
             return;
         }
 
         const payload = { items: payloadItems };
         let url;
-        if (isOffer) {
+        if (transactionKind === 'offer') {
             url = `/customers/${entityId}/offers/`;
-        } else {
+            payload.details = description || undefined;
+        } else if (transactionKind === 'sale') {
             url = '/sales/';
-            payload.customer_id = entityId;
+            if (isSupplierSale) {
+                payload.supplier_id = Number(entityId);
+            } else {
+                payload.customer_id = Number(entityId);
+            }
             payload.sale_date = saleDate;
+            payload.invoice_number = invoiceNumber || undefined;
+            payload.details = description || undefined;
+        } else {
+            url = '/purchases/';
+            payload.supplier_id = Number(entityId);
+            payload.purchase_date = saleDate;
+            payload.bill_number = invoiceNumber || undefined;
         }
 
         try {
@@ -186,8 +246,8 @@ function SaleFormPage() {
             await axiosInstance.post(url, payload);
             navigate(isSupplierSale ? `/suppliers/${entityId}` : `/customers/${entityId}`);
         } catch (error) {
-            console.error('Failed to create sale', error.response?.data);
-            setFormError(error.response?.data?.detail || 'Failed to save the sale.');
+            console.error('Failed to create transaction', error.response?.data);
+            setFormError(error.response?.data?.detail || 'Failed to save the transaction.');
         } finally {
             setIsSubmitting(false);
         }
@@ -211,9 +271,29 @@ function SaleFormPage() {
                     <Col xl={4} lg={5} className="mb-4">
                         <Card className="sale-form__sidebar-card">
                             <Card.Header>
-                                <div className="sale-form__sidebar-title">
-                                    <div className="sale-form__sidebar-label">{isOffer ? 'Offer' : 'Sale'} Summary</div>
-                                    <div className="sale-form__sidebar-entity">{customer.name}</div>
+                                <div className="sale-form__sidebar-header">
+                                    <div className="sale-form__sidebar-title">
+                                        <div className="sale-form__sidebar-label">{transactionLabel} Summary</div>
+                                        <div className="sale-form__sidebar-entity">{customer.name}</div>
+                                    </div>
+                                    {isSupplierSale && (
+                                        <div className="sale-form__mode-toggle">
+                                            <Button
+                                                size="sm"
+                                                variant={supplierTransactionType === 'sell' ? 'light' : 'outline-light'}
+                                                onClick={() => handleSupplierModeChange('sell')}
+                                            >
+                                                Sell to Supplier
+                                            </Button>
+                                            <Button
+                                                size="sm"
+                                                variant={supplierTransactionType === 'buy' ? 'light' : 'outline-light'}
+                                                onClick={() => handleSupplierModeChange('buy')}
+                                            >
+                                                Buy from Supplier
+                                            </Button>
+                                        </div>
+                                    )}
                                 </div>
                             </Card.Header>
                             <Card.Body>
@@ -236,7 +316,7 @@ function SaleFormPage() {
                                     </Col>
                                     <Col md={6}>
                                         <Form.Group controlId="saleDate">
-                                            <Form.Label>{isOffer ? 'Offer Date' : 'Sale Date'}</Form.Label>
+                                            <Form.Label>{saleDateLabel}</Form.Label>
                                             <Form.Control
                                                 type="date"
                                                 value={saleDate}
@@ -246,7 +326,7 @@ function SaleFormPage() {
                                     </Col>
                                     <Col md={6}>
                                         <Form.Group controlId="invoiceDate">
-                                            <Form.Label>Invoice Date</Form.Label>
+                                            <Form.Label>{invoiceDateLabel}</Form.Label>
                                             <Form.Control
                                                 type="date"
                                                 value={invoiceDate}
@@ -256,7 +336,7 @@ function SaleFormPage() {
                                     </Col>
                                     <Col md={6}>
                                         <Form.Group controlId="invoiceNumber">
-                                            <Form.Label>Invoice No</Form.Label>
+                                            <Form.Label>{invoiceNumberLabel}</Form.Label>
                                             <Form.Control
                                                 type="text"
                                                 value={invoiceNumber}
@@ -283,12 +363,14 @@ function SaleFormPage() {
                                         <span>Subtotal</span>
                                         <span>{formatCurrency(totals.base)}</span>
                                     </div>
-                                    <div className="sale-form__summary-row">
-                                        <span>Discount</span>
-                                        <span>{formatCurrency(totals.discount)}</span>
-                                    </div>
+                                    {allowDiscounts && (
+                                        <div className="sale-form__summary-row">
+                                            <span>Discount</span>
+                                            <span>{formatCurrency(totals.discount)}</span>
+                                        </div>
+                                    )}
                                     <div className="sale-form__summary-row sale-form__summary-row--strong">
-                                        <span>Net Total</span>
+                                        <span>{transactionLabel} Total</span>
                                         <span>{formatCurrency(totals.net)}</span>
                                     </div>
                                 </div>
@@ -300,7 +382,7 @@ function SaleFormPage() {
                                         variant="success"
                                         disabled={!hasWarehouses || !hasLineItems || isSubmitting}
                                     >
-                                        {isOffer ? 'Save Offer' : 'Save Sale'}
+                                        {submitLabel}
                                     </Button>
                                     <Button
                                         variant="outline-secondary"
@@ -319,7 +401,9 @@ function SaleFormPage() {
                                 <div className="sale-form__items-header">
                                     <div>
                                         <h5 className="mb-0">Products &amp; Services</h5>
-                                        <small className="text-muted">Add items from your catalog to this {isOffer ? 'offer' : 'sale'}.</small>
+                                        <small className="text-muted">
+                                            Add items from your catalog to this {transactionLabel.toLowerCase()}.
+                                        </small>
                                     </div>
                                     <div className="sale-form__quick-add">
                                         <ProductSearchSelect
@@ -345,7 +429,7 @@ function SaleFormPage() {
                             <Card.Body>
                                 {!hasWarehouses && (
                                     <Alert variant="warning" className="mb-3">
-                                        No warehouses available. Please create a warehouse before recording sales.
+                                        No warehouses available. Please create a warehouse before recording this transaction.
                                     </Alert>
                                 )}
                                 {formError && (
@@ -371,7 +455,7 @@ function SaleFormPage() {
                                             {lineItems.length === 0 && (
                                                 <tr>
                                                     <td colSpan={8} className="text-center text-muted py-4">
-                                                        Add products using the search above to build this {isOffer ? 'offer' : 'sale'}.
+                                                        Add products using the search above to build this {transactionLabel.toLowerCase()}.
                                                     </td>
                                                 </tr>
                                             )}
@@ -454,6 +538,7 @@ function SaleFormPage() {
                 warehouses={warehouses}
                 currency={customer.currency}
                 imageBaseUrl={baseApiUrl}
+                priceField={priceField}
             />
         </Container>
     );

--- a/frontend/src/styles/saleForm.css
+++ b/frontend/src/styles/saleForm.css
@@ -213,6 +213,20 @@
     background: linear-gradient(135deg, #3a7bd5 0%, #3a6073 100%);
     color: #fff;
     padding: 1.5rem;
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+.sale-form__sidebar-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    width: 100%;
+    gap: 1rem;
+    flex-wrap: wrap;
 }
 
 .sale-form__sidebar-title {
@@ -226,6 +240,29 @@
     text-transform: uppercase;
     letter-spacing: 0.08em;
     opacity: 0.85;
+}
+
+.sale-form__mode-toggle {
+    display: inline-flex;
+    gap: 0.5rem;
+}
+
+.sale-form__mode-toggle .btn {
+    border-radius: 999px;
+    font-weight: 600;
+    padding-inline: 1.1rem;
+    box-shadow: 0 12px 20px -14px rgba(15, 23, 42, 0.6);
+}
+
+.sale-form__mode-toggle .btn-outline-light {
+    color: #fff;
+    border-color: rgba(255, 255, 255, 0.6);
+}
+
+.sale-form__mode-toggle .btn-outline-light:hover,
+.sale-form__mode-toggle .btn-outline-light:focus {
+    color: #1e293b;
+    background: #fff;
 }
 
 .sale-form__sidebar-entity {


### PR DESCRIPTION
## Summary
- allow the sale form to switch between selling to or buying from a supplier
- reuse pricing and validation logic for both customer and supplier workflows, including modal defaults and totals
- style the sidebar header with a mode toggle that matches the refreshed layout

## Testing
- CI=true npm test

------
https://chatgpt.com/codex/tasks/task_e_68d76e2678988323890a7ee3afdadb31