### PR TITLE
Revamp edit flows to match refreshed UI

### DIFF
--- a/frontend/src/styles/paymentModal.css
+++ b/frontend/src/styles/paymentModal.css
@@ -1,0 +1,142 @@
+.payment-modal .modal-content {
+    border-radius: 1.2rem;
+    border: none;
+    box-shadow: 0 28px 60px -28px rgba(15, 23, 42, 0.45);
+    overflow: hidden;
+}
+
+.payment-modal .modal-header {
+    background: linear-gradient(135deg, #2563eb 0%, #1d4ed8 100%);
+    color: #fff;
+    border-bottom: none;
+    padding: 1.5rem 1.75rem;
+}
+
+.payment-modal .modal-header .btn-close {
+    filter: invert(1);
+    opacity: 0.75;
+}
+
+.payment-modal__title {
+    font-size: 1.25rem;
+    font-weight: 600;
+    margin-bottom: 0.3rem;
+}
+
+.payment-modal__subtitle {
+    font-size: 0.95rem;
+    opacity: 0.85;
+}
+
+.payment-modal .modal-body {
+    background: linear-gradient(180deg, #f8fbff 0%, #eef2ff 100%);
+    padding: 1.75rem;
+}
+
+.payment-modal__alert {
+    border-radius: 0.85rem;
+    padding: 0.9rem 1.1rem;
+}
+
+.payment-modal__grid {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.payment-modal__field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+}
+
+.payment-modal__field .form-control,
+.payment-modal__field .form-select {
+    border-radius: 0.9rem;
+    border: 1px solid rgba(148, 163, 184, 0.25);
+    background: rgba(255, 255, 255, 0.9);
+    box-shadow: inset 0 1px 2px rgba(15, 23, 42, 0.04);
+    padding: 0.65rem 0.85rem;
+}
+
+.payment-modal__field .form-control:focus,
+.payment-modal__field .form-select:focus {
+    border-color: rgba(37, 99, 235, 0.6);
+    box-shadow: 0 0 0 0.2rem rgba(37, 99, 235, 0.18);
+    background: #fff;
+}
+
+.payment-modal__field--wide {
+    grid-column: 1 / -1;
+}
+
+.payment-modal__summary {
+    margin-top: 1.75rem;
+    padding: 1.25rem 1.5rem;
+    background: rgba(37, 99, 235, 0.08);
+    border-radius: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.85rem;
+}
+
+.payment-modal__summary-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 0.95rem;
+    color: #1e293b;
+}
+
+.payment-modal__summary-label {
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: 0.75rem;
+    color: #475569;
+}
+
+.payment-modal__summary-value {
+    font-weight: 700;
+    font-size: 1.05rem;
+    color: #0f172a;
+}
+
+.payment-modal__summary-note {
+    font-size: 0.9rem;
+    color: #475569;
+}
+
+.payment-modal__footer {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 1.25rem 1.75rem 1.5rem;
+    background: #fff;
+    border-top: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.payment-modal__footer .btn {
+    min-width: 140px;
+    border-radius: 0.85rem;
+    font-weight: 600;
+}
+
+.payment-modal__footer .btn-primary {
+    box-shadow: 0 12px 28px -12px rgba(37, 99, 235, 0.4);
+}
+
+@media (max-width: 576px) {
+    .payment-modal .modal-body {
+        padding: 1.35rem;
+    }
+
+    .payment-modal__footer {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .payment-modal__footer .btn {
+        width: 100%;
+    }
+}

--- a/frontend/src/styles/saleForm.css
+++ b/frontend/src/styles/saleForm.css
@@ -384,6 +384,27 @@
     gap: 0.35rem;
 }
 
+.sale-items-table__field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.sale-items-table__field .form-select,
+.sale-items-table__field .form-control {
+    border-radius: 0.9rem;
+    border: 1px solid rgba(148, 163, 184, 0.25);
+    background: rgba(248, 250, 255, 0.8);
+    box-shadow: inset 0 1px 2px rgba(15, 23, 42, 0.04);
+}
+
+.sale-items-table__field .form-select:focus,
+.sale-items-table__field .form-control:focus {
+    border-color: rgba(37, 99, 235, 0.55);
+    box-shadow: 0 0 0 0.2rem rgba(37, 99, 235, 0.18);
+    background: #fff;
+}
+
 .sale-items-table__name {
     font-weight: 600;
     color: #1e293b;


### PR DESCRIPTION
## Summary
- restyle the sale edit workflow with the new layout, customer summary card, and modernised items table
- update the purchase edit screen to mirror the refreshed sale experience, including totals and richer item rows
- redesign customer and supplier payment modals with gradient headers, currency summaries, and shared styling helpers

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7b7440e24832389d5624f1456ef8d