### PR TITLE
Improve form input readability

### DIFF
--- a/frontend/src/styles/theme.css
+++ b/frontend/src/styles/theme.css
@@ -196,6 +196,16 @@ body {
   box-shadow: none;
 }
 
+.form-control,
+.form-select {
+  color: var(--text-color-primary, var(--color-neutral-900, #0f172a));
+}
+
+.form-control::placeholder {
+  color: var(--text-color-secondary, var(--color-neutral-700, #334155));
+  opacity: 0.65;
+}
+
 .btn-ghost:hover,
 .btn-ghost:focus {
   background: rgba(15, 23, 42, 0.06);


### PR DESCRIPTION
## Summary
- ensure all Bootstrap form controls inherit a dark, high-contrast text color
- adjust placeholder styling so helper text remains legible against light input backgrounds

## Testing
- CI=1 HOST=0.0.0.0 PORT=3000 npm start

------
https://chatgpt.com/codex/tasks/task_e_68d7bb10176c832399c9c97c8a9adf8f