### PR TITLE
Add product thumbnails to product displays

### DIFF
--- a/frontend/src/pages/CustomerDetailPage.js
+++ b/frontend/src/pages/CustomerDetailPage.js
@@ -1,6 +1,6 @@
 // frontend/src/pages/CustomerDetailPage.js
 
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import axiosInstance from '../utils/axiosInstance';
 import { Container, Card, Row, Col, Spinner, Alert, Button, Accordion, ButtonToolbar, Table, Modal } from 'react-bootstrap';
@@ -10,8 +10,9 @@ import CustomerPaymentModal from '../components/CustomerPaymentModal';
 import ActionMenu from '../components/ActionMenu';
 import '../styles/datatable.css';
 import '../styles/transaction-history.css';
+import { getBaseApiUrl, getImageInitial, resolveImageUrl } from '../utils/image';
 
-const API_BASE_URL = 'http://127.0.0.1:8000';
+const BASE_API_URL = getBaseApiUrl();
 
 function CustomerDetailPage() {
     const { id } = useParams();
@@ -123,8 +124,8 @@ function CustomerDetailPage() {
             <Card className="mb-3" style={{ background: '#f5f5f5' }}>
                 <Card.Body className="d-flex align-items-center customer-header">
                     {customer.image ? (
-                        <img
-                            src={`${API_BASE_URL}${customer.image}`}
+                                <img
+                                    src={`${BASE_API_URL}${customer.image}`}
                             alt={customer.name}
                             className="rounded-circle me-3 customer-image"
                             style={{ width: '60px', height: '60px' }}
@@ -195,7 +196,7 @@ function CustomerDetailPage() {
             <Modal show={showImageModal} onHide={handleCloseImageModal} centered>
                 <Modal.Body className="text-center">
                     {customer.image && (
-                        <img src={`${API_BASE_URL}${customer.image}`} alt={customer.name} className="img-fluid" />
+                        <img src={`${BASE_API_URL}${customer.image}`} alt={customer.name} className="img-fluid" />
                     )}
                 </Modal.Body>
             </Modal>
@@ -281,16 +282,37 @@ function CustomerDetailPage() {
                                                             </tr>
                                                         </thead>
                                                         <tbody>
-                                                            {saleItems.map(item => (
-                                                                <tr key={item.id}>
-                                                                    <td>{item.product_name}</td>
-                                                                    <td>{item.quantity}</td>
-                                                                    <td>{formatCurrency(item.unit_price, customer.currency)}</td>
-                                                                    <td className="text-end">
-                                                                        {formatCurrency(item.line_total, customer.currency)}
-                                                                    </td>
-                                                                </tr>
-                                                            ))}
+                                                            {saleItems.map(item => {
+                                                                const productImage = resolveImageUrl(
+                                                                    item.product_image || item.product?.image,
+                                                                    BASE_API_URL
+                                                                );
+                                                                const imageInitial = getImageInitial(item.product_name);
+
+                                                                return (
+                                                                    <tr key={item.id}>
+                                                                        <td>
+                                                                            <div className="product-name-cell">
+                                                                                <div className="product-name-cell__image">
+                                                                                    {productImage ? (
+                                                                                        <img src={productImage} alt={item.product_name} />
+                                                                                    ) : (
+                                                                                        <span>{imageInitial}</span>
+                                                                                    )}
+                                                                                </div>
+                                                                                <div className="product-name-cell__info">
+                                                                                    <div className="product-name-cell__name">{item.product_name}</div>
+                                                                                </div>
+                                                                            </div>
+                                                                        </td>
+                                                                        <td>{item.quantity}</td>
+                                                                        <td>{formatCurrency(item.unit_price, customer.currency)}</td>
+                                                                        <td className="text-end">
+                                                                            {formatCurrency(item.line_total, customer.currency)}
+                                                                        </td>
+                                                                    </tr>
+                                                                );
+                                                            })}
                                                         </tbody>
                                                     </Table>
                                                 </Accordion.Body>
@@ -436,16 +458,37 @@ function CustomerDetailPage() {
                                                             <th className="text-end">Line Total</th>
                                                         </tr>
                                                     </thead>
-                                                    <tbody>
-                                                        {purchase.items.map(item => (
-                                                            <tr key={item.id}>
-                                                                <td>{item.product_name}</td>
-                                                                <td>{item.quantity}</td>
-                                                                <td>{formatCurrency(item.unit_price, customer.currency)}</td>
-                                                                <td className="text-end">{formatCurrency(item.line_total, customer.currency)}</td>
-                                                            </tr>
-                                                        ))}
-                                                    </tbody>
+                                                      <tbody>
+                                                          {purchase.items.map(item => {
+                                                              const productImage = resolveImageUrl(
+                                                                  item.product_image || item.product?.image,
+                                                                  BASE_API_URL
+                                                              );
+                                                              const imageInitial = getImageInitial(item.product_name);
+
+                                                              return (
+                                                                  <tr key={item.id}>
+                                                                      <td>
+                                                                          <div className="product-name-cell">
+                                                                              <div className="product-name-cell__image">
+                                                                                  {productImage ? (
+                                                                                      <img src={productImage} alt={item.product_name} />
+                                                                                  ) : (
+                                                                                      <span>{imageInitial}</span>
+                                                                                  )}
+                                                                              </div>
+                                                                              <div className="product-name-cell__info">
+                                                                                  <div className="product-name-cell__name">{item.product_name}</div>
+                                                                              </div>
+                                                                          </div>
+                                                                      </td>
+                                                                      <td>{item.quantity}</td>
+                                                                      <td>{formatCurrency(item.unit_price, customer.currency)}</td>
+                                                                      <td className="text-end">{formatCurrency(item.line_total, customer.currency)}</td>
+                                                                  </tr>
+                                                              );
+                                                          })}
+                                                      </tbody>
                                                 </Table>
                                             </Accordion.Body>
                                         </Accordion.Item>

--- a/frontend/src/pages/EditPurchasePage.js
+++ b/frontend/src/pages/EditPurchasePage.js
@@ -1,12 +1,13 @@
 // frontend/src/pages/EditPurchasePage.js
 
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import axiosInstance from '../utils/axiosInstance';
 import { useNavigate, useParams } from 'react-router-dom';
 import { Alert, Badge, Button, Card, Col, Container, Form, Row, Spinner, Stack, Table } from 'react-bootstrap';
 import { FaTrash } from 'react-icons/fa';
 import { formatCurrency } from '../utils/format';
 import '../styles/saleForm.css';
+import { getBaseApiUrl, getImageInitial, resolveImageUrl } from '../utils/image';
 
 function EditPurchasePage() {
     const { id } = useParams();
@@ -32,6 +33,7 @@ function EditPurchasePage() {
     const [error, setError] = useState('');
 
     const hasWarehouses = warehouses.length > 0;
+    const baseApiUrl = useMemo(() => getBaseApiUrl(), []);
 
     useEffect(() => {
         const fetchInitialData = async () => {
@@ -325,29 +327,40 @@ function EditPurchasePage() {
                                                 );
                                                 const availableStock = warehouseQuantity ? Number(warehouseQuantity.quantity) : null;
                                                 const lineTotal = (Number(item.quantity) || 0) * (Number(item.unit_price) || 0);
+                                                const resolvedImage = resolveImageUrl(product?.image, baseApiUrl);
+                                                const imageInitial = getImageInitial(product?.name);
 
                                                 return (
                                                     <tr key={`${index}-${item.product_id || 'new'}`}>
                                                         <td>
-                                                            <div className="sale-items-table__product">
-                                                                <div className="sale-items-table__field">
-                                                                    <Form.Select
-                                                                        name="product_id"
-                                                                        value={item.product_id}
-                                                                        onChange={(event) => handleItemChange(index, event)}
-                                                                        required
-                                                                    >
-                                                                        <option value="">Select a Product</option>
-                                                                        {products.map((productOption) => (
-                                                                            <option key={productOption.id} value={productOption.id}>
-                                                                                {productOption.name}
-                                                                            </option>
-                                                                        ))}
-                                                                    </Form.Select>
+                                                            <div className="sale-items-table__product product-name-cell">
+                                                                <div className="product-name-cell__image">
+                                                                    {resolvedImage ? (
+                                                                        <img src={resolvedImage} alt={product?.name || 'Product preview'} />
+                                                                    ) : (
+                                                                        <span>{imageInitial}</span>
+                                                                    )}
                                                                 </div>
-                                                                <div className="sale-items-table__meta">
-                                                                    {product?.sku && <span>SKU: {product.sku}</span>}
-                                                                    {product?.category_name && <span>{product.category_name}</span>}
+                                                                <div className="sale-items-table__info product-name-cell__info">
+                                                                    <div className="sale-items-table__field">
+                                                                        <Form.Select
+                                                                            name="product_id"
+                                                                            value={item.product_id}
+                                                                            onChange={(event) => handleItemChange(index, event)}
+                                                                            required
+                                                                        >
+                                                                            <option value="">Select a Product</option>
+                                                                            {products.map((productOption) => (
+                                                                                <option key={productOption.id} value={productOption.id}>
+                                                                                    {productOption.name}
+                                                                                </option>
+                                                                            ))}
+                                                                        </Form.Select>
+                                                                    </div>
+                                                                    <div className="sale-items-table__meta product-name-cell__meta">
+                                                                        {product?.sku && <span>SKU: {product.sku}</span>}
+                                                                        {product?.category_name && <span>{product.category_name}</span>}
+                                                                    </div>
                                                                 </div>
                                                             </div>
                                                         </td>

--- a/frontend/src/pages/OfferDetailPage.js
+++ b/frontend/src/pages/OfferDetailPage.js
@@ -1,9 +1,12 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import axiosInstance from '../utils/axiosInstance';
 import { Card, Button, Spinner, Alert, Row, Col, Table } from 'react-bootstrap';
 import { formatCurrency } from '../utils/format';
 import '../styles/datatable.css';
+import { getBaseApiUrl, getImageInitial, resolveImageUrl } from '../utils/image';
+
+const BASE_API_URL = getBaseApiUrl();
 
 function OfferDetailPage() {
     const { id } = useParams();
@@ -87,15 +90,36 @@ function OfferDetailPage() {
                                     </tr>
                                 </thead>
                                 <tbody>
-                                    {offer.items.map((item, index) => (
-                                        <tr key={item.id}>
-                                            <td>{index + 1}</td>
-                                            <td>{item.product_name}</td>
-                                            <td>{item.quantity}</td>
-                                            <td>{formatCurrency(item.unit_price)}</td>
-                                            <td>{formatCurrency(item.quantity * item.unit_price)}</td>
-                                        </tr>
-                                    ))}
+                                    {offer.items.map((item, index) => {
+                                        const productImage = resolveImageUrl(
+                                            item.product_image || item.product?.image,
+                                            BASE_API_URL
+                                        );
+                                        const imageInitial = getImageInitial(item.product_name);
+
+                                        return (
+                                            <tr key={item.id}>
+                                                <td>{index + 1}</td>
+                                                <td>
+                                                    <div className="product-name-cell">
+                                                        <div className="product-name-cell__image">
+                                                            {productImage ? (
+                                                                <img src={productImage} alt={item.product_name} />
+                                                            ) : (
+                                                                <span>{imageInitial}</span>
+                                                            )}
+                                                        </div>
+                                                        <div className="product-name-cell__info">
+                                                            <div className="product-name-cell__name">{item.product_name}</div>
+                                                        </div>
+                                                    </div>
+                                                </td>
+                                                <td>{item.quantity}</td>
+                                                <td>{formatCurrency(item.unit_price)}</td>
+                                                <td>{formatCurrency(item.quantity * item.unit_price)}</td>
+                                            </tr>
+                                        );
+                                    })}
                                 </tbody>
                             </Table>
                         </div>

--- a/frontend/src/pages/PurchaseDetailPage.js
+++ b/frontend/src/pages/PurchaseDetailPage.js
@@ -6,6 +6,9 @@ import axiosInstance from '../utils/axiosInstance';
 import { Card, Button, Spinner, Alert, Row, Col, Table } from 'react-bootstrap';
 import { formatCurrency } from '../utils/format';
 import '../styles/datatable.css';
+import { getBaseApiUrl, getImageInitial, resolveImageUrl } from '../utils/image';
+
+const BASE_API_URL = getBaseApiUrl();
 
 function PurchaseDetailPage() {
     const { id } = useParams();
@@ -60,17 +63,46 @@ function PurchaseDetailPage() {
                           <h5>Items Purchased</h5>
                           <div className="data-table-container">
                             <Table responsive className="data-table data-table--compact">
-                                <thead><tr><th>Product</th><th>Quantity</th><th>Warehouse</th><th>Unit Price</th><th>Line Total</th></tr></thead>
+                                <thead>
+                                    <tr>
+                                        <th>Product</th>
+                                        <th>Quantity</th>
+                                        <th>Warehouse</th>
+                                        <th>Unit Price</th>
+                                        <th>Line Total</th>
+                                    </tr>
+                                </thead>
                                 <tbody>
-                                    {purchase.items.map(item => (
-                                        <tr key={item.id}>
-                                            <td>{item.product_name}</td>
-                                            <td>{item.quantity}</td>
-                                            <td>{item.warehouse_name || '—'}</td>
-                                            <td>{formatCurrency(item.unit_price, purchase.original_currency || 'USD')}</td>
-                                            <td>{formatCurrency(item.line_total, purchase.original_currency || 'USD')}</td>
-                                        </tr>
-                                    ))}
+                                    {purchase.items.map(item => {
+                                        const productImage = resolveImageUrl(
+                                            item.product_image || item.product?.image,
+                                            BASE_API_URL
+                                        );
+                                        const imageInitial = getImageInitial(item.product_name);
+
+                                        return (
+                                            <tr key={item.id}>
+                                                <td>
+                                                    <div className="product-name-cell">
+                                                        <div className="product-name-cell__image">
+                                                            {productImage ? (
+                                                                <img src={productImage} alt={item.product_name} />
+                                                            ) : (
+                                                                <span>{imageInitial}</span>
+                                                            )}
+                                                        </div>
+                                                        <div className="product-name-cell__info">
+                                                            <div className="product-name-cell__name">{item.product_name}</div>
+                                                        </div>
+                                                    </div>
+                                                </td>
+                                                <td>{item.quantity}</td>
+                                                <td>{item.warehouse_name || '—'}</td>
+                                                <td>{formatCurrency(item.unit_price, purchase.original_currency || 'USD')}</td>
+                                                <td>{formatCurrency(item.line_total, purchase.original_currency || 'USD')}</td>
+                                            </tr>
+                                        );
+                                    })}
                                 </tbody>
                             </Table>
                           </div>

--- a/frontend/src/pages/PurchaseFormPage.js
+++ b/frontend/src/pages/PurchaseFormPage.js
@@ -8,6 +8,7 @@ import axiosInstance from '../utils/axiosInstance';
 import '../styles/saleForm.css';
 import ProductSearchSelect from '../components/ProductSearchSelect';
 import PurchaseItemModal from '../components/PurchaseItemModal';
+import { getBaseApiUrl, getImageInitial, resolveImageUrl } from '../utils/image';
 
 function PurchaseFormPage() {
     const { supplierId, customerId } = useParams();
@@ -57,10 +58,7 @@ function PurchaseFormPage() {
         );
     }, [warehouses]);
 
-    const baseApiUrl = useMemo(() => {
-        const apiBase = axiosInstance.defaults.baseURL || '';
-        return apiBase.replace(/\/?api\/?$/, '');
-    }, []);
+    const baseApiUrl = useMemo(() => getBaseApiUrl(), []);
 
     const getProductById = useCallback(
         (productId) => {
@@ -383,15 +381,26 @@ function PurchaseFormPage() {
                                                 const availableStock = warehouseQuantity ? Number(warehouseQuantity.quantity) : null;
                                                 const discountLabel = item.discount ? `${Number(item.discount).toFixed(2)}%` : '—';
                                                 const lineTotal = Number(item.quantity) * Number(item.unit_price || 0);
+                                                const resolvedImage = resolveImageUrl(product?.image, baseApiUrl);
+                                                const imageInitial = getImageInitial(product?.name);
 
                                                 return (
                                                     <tr key={`${item.product_id}-${index}`}>
                                                         <td>
-                                                            <div className="sale-items-table__product">
-                                                                <div className="sale-items-table__name">{product?.name || 'Unnamed product'}</div>
-                                                                <div className="sale-items-table__meta">
-                                                                    {product?.sku && <span>SKU: {product.sku}</span>}
-                                                                    {item.note && <span>Note: {item.note}</span>}
+                                                            <div className="sale-items-table__product product-name-cell">
+                                                                <div className="product-name-cell__image">
+                                                                    {resolvedImage ? (
+                                                                        <img src={resolvedImage} alt={product?.name || 'Product preview'} />
+                                                                    ) : (
+                                                                        <span>{imageInitial}</span>
+                                                                    )}
+                                                                </div>
+                                                                <div className="sale-items-table__info product-name-cell__info">
+                                                                    <div className="sale-items-table__name product-name-cell__name">{product?.name || 'Unnamed product'}</div>
+                                                                    <div className="sale-items-table__meta product-name-cell__meta">
+                                                                        {product?.sku && <span>SKU: {product.sku}</span>}
+                                                                        {item.note && <span>Note: {item.note}</span>}
+                                                                    </div>
                                                                 </div>
                                                             </div>
                                                         </td>

--- a/frontend/src/pages/SaleDetailPage.js
+++ b/frontend/src/pages/SaleDetailPage.js
@@ -1,12 +1,15 @@
 // frontend/src/pages/SaleDetailPage.js
 
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useParams, useNavigate, Link } from 'react-router-dom';
 import axiosInstance from '../utils/axiosInstance';
 import { Card, Button, Spinner, Alert, Row, Col, Table } from 'react-bootstrap';
 import AddPaymentModal from '../components/AddPaymentModal';
 import { getBaseCurrency, loadBaseCurrency } from '../config/currency';
 import '../styles/datatable.css';
+import { getBaseApiUrl, getImageInitial, resolveImageUrl } from '../utils/image';
+
+const BASE_API_URL = getBaseApiUrl();
 
 function SaleDetailPage() {
     const { id } = useParams();
@@ -165,7 +168,6 @@ const balanceDueBase = sale ? parseFloat(sale.converted_amount || sale.total_amo
                                     <tr>
                                         <th>#</th>
                                         <th>Product</th>
-                                        <th>Image</th>
                                         <th>Quantity</th>
                                         <th>Warehouse</th>
                                         <th>Unit Price</th>
@@ -173,27 +175,37 @@ const balanceDueBase = sale ? parseFloat(sale.converted_amount || sale.total_amo
                                     </tr>
                                 </thead>
                                 <tbody>
-                                    {sale.items.map((item, index) => (
-                                        <tr key={item.id}>
-                                            <td>{index + 1}</td>
-                                            <td>{item.product_name}</td>
-                                            <td>
-                                                {item.product_image ? (
-                                                    <img
-                                                        src={item.product_image}
-                                                        alt={item.product_name}
-                                                        style={{ width: '60px', height: '60px', objectFit: 'contain' }}
-                                                    />
-                                                ) : (
-                                                    <span className="text-muted">No image</span>
-                                                )}
-                                            </td>
-                                            <td>{item.quantity}</td>
-                                            <td>{item.warehouse_name || '—'}</td>
-                                            <td>{formatCurrency(item.unit_price, sale.original_currency)}</td>
-                                            <td>{formatCurrency(item.quantity * item.unit_price, sale.original_currency)}</td>
-                                        </tr>
-                                    ))}
+                                    {sale.items.map((item, index) => {
+                                        const productImage = resolveImageUrl(
+                                            item.product_image || item.product?.image,
+                                            BASE_API_URL
+                                        );
+                                        const imageInitial = getImageInitial(item.product_name);
+
+                                        return (
+                                            <tr key={item.id}>
+                                                <td>{index + 1}</td>
+                                                <td>
+                                                    <div className="product-name-cell">
+                                                        <div className="product-name-cell__image">
+                                                            {productImage ? (
+                                                                <img src={productImage} alt={item.product_name} />
+                                                            ) : (
+                                                                <span>{imageInitial}</span>
+                                                            )}
+                                                        </div>
+                                                        <div className="product-name-cell__info">
+                                                            <div className="product-name-cell__name">{item.product_name}</div>
+                                                        </div>
+                                                    </div>
+                                                </td>
+                                                <td>{item.quantity}</td>
+                                                <td>{item.warehouse_name || '—'}</td>
+                                                <td>{formatCurrency(item.unit_price, sale.original_currency)}</td>
+                                                <td>{formatCurrency(item.quantity * item.unit_price, sale.original_currency)}</td>
+                                            </tr>
+                                        );
+                                    })}
                                 </tbody>
                             </Table>
                         </div>

--- a/frontend/src/pages/SaleFormPage.js
+++ b/frontend/src/pages/SaleFormPage.js
@@ -9,6 +9,7 @@ import '../styles/datatable.css';
 import '../styles/saleForm.css';
 import ProductSearchSelect from '../components/ProductSearchSelect';
 import SaleItemModal from '../components/SaleItemModal';
+import { getBaseApiUrl, getImageInitial, resolveImageUrl } from '../utils/image';
 
 function SaleFormPage({
     mode: modeProp,
@@ -166,10 +167,7 @@ function SaleFormPage({
         );
     }, [warehouses]);
 
-    const baseApiUrl = useMemo(() => {
-        const apiBase = axiosInstance.defaults.baseURL || '';
-        return apiBase.replace(/\/?api\/?$/, '');
-    }, []);
+    const baseApiUrl = useMemo(() => getBaseApiUrl(), []);
 
     const getProductById = useCallback((productId) => {
         if (!productId) return null;
@@ -659,15 +657,26 @@ function SaleFormPage({
                                                 const availableStock = warehouseQuantity ? Number(warehouseQuantity.quantity) : null;
                                                 const discountLabel = item.discount ? `${Number(item.discount).toFixed(2)}%` : '—';
                                                 const lineTotal = Number(item.quantity) * Number(item.unit_price || 0);
+                                                const resolvedImage = resolveImageUrl(product?.image, baseApiUrl);
+                                                const imageInitial = getImageInitial(product?.name);
 
                                                 return (
                                                     <tr key={`${item.product_id}-${index}`}>
                                                         <td>
-                                                            <div className="sale-items-table__product">
-                                                                <div className="sale-items-table__name">{product?.name || 'Unnamed product'}</div>
-                                                                <div className="sale-items-table__meta">
-                                                                    {product?.sku && <span>SKU: {product.sku}</span>}
-                                                                    {item.note && <span>Note: {item.note}</span>}
+                                                            <div className="sale-items-table__product product-name-cell">
+                                                                <div className="product-name-cell__image">
+                                                                    {resolvedImage ? (
+                                                                        <img src={resolvedImage} alt={product?.name || 'Product preview'} />
+                                                                    ) : (
+                                                                        <span>{imageInitial}</span>
+                                                                    )}
+                                                                </div>
+                                                                <div className="sale-items-table__info product-name-cell__info">
+                                                                    <div className="sale-items-table__name product-name-cell__name">{product?.name || 'Unnamed product'}</div>
+                                                                    <div className="sale-items-table__meta product-name-cell__meta">
+                                                                        {product?.sku && <span>SKU: {product.sku}</span>}
+                                                                        {item.note && <span>Note: {item.note}</span>}
+                                                                    </div>
                                                                 </div>
                                                             </div>
                                                         </td>

--- a/frontend/src/pages/SaleListPage.js
+++ b/frontend/src/pages/SaleListPage.js
@@ -1,6 +1,6 @@
 // frontend/src/pages/SaleListPage.js
 
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import axiosInstance from '../utils/axiosInstance';
 import { Container, Card, Button, Alert, Spinner, Accordion, Table } from 'react-bootstrap';
@@ -9,6 +9,9 @@ import ActionMenu from '../components/ActionMenu';
 import { formatCurrency } from '../utils/format';
 import '../styles/datatable.css';
 import '../styles/transaction-history.css';
+import { getBaseApiUrl, getImageInitial, resolveImageUrl } from '../utils/image';
+
+const BASE_API_URL = getBaseApiUrl();
 
 function SaleListPage() {
     const [sales, setSales] = useState([]);
@@ -166,16 +169,37 @@ function SaleListPage() {
                                                         </tr>
                                                     </thead>
                                                     <tbody>
-                                                        {saleItems.map(item => (
-                                                            <tr key={item.id || `${sale.id}-${item.product_name}`}>
-                                                                <td>{item.product_name}</td>
-                                                                <td>{item.quantity}</td>
-                                                                <td>{formatCurrency(item.unit_price, sale.original_currency || 'USD')}</td>
-                                                                <td className="text-end">
-                                                                    {formatCurrency(item.line_total, sale.original_currency || 'USD')}
-                                                                </td>
-                                                            </tr>
-                                                        ))}
+                                                        {saleItems.map(item => {
+                                                            const productImage = resolveImageUrl(
+                                                                item.product_image || item.product?.image,
+                                                                BASE_API_URL
+                                                            );
+                                                            const imageInitial = getImageInitial(item.product_name);
+
+                                                            return (
+                                                                <tr key={item.id || `${sale.id}-${item.product_name}`}>
+                                                                    <td>
+                                                                        <div className="product-name-cell">
+                                                                            <div className="product-name-cell__image">
+                                                                                {productImage ? (
+                                                                                    <img src={productImage} alt={item.product_name} />
+                                                                                ) : (
+                                                                                    <span>{imageInitial}</span>
+                                                                                )}
+                                                                            </div>
+                                                                            <div className="product-name-cell__info">
+                                                                                <div className="product-name-cell__name">{item.product_name}</div>
+                                                                            </div>
+                                                                        </div>
+                                                                    </td>
+                                                                    <td>{item.quantity}</td>
+                                                                    <td>{formatCurrency(item.unit_price, sale.original_currency || 'USD')}</td>
+                                                                    <td className="text-end">
+                                                                        {formatCurrency(item.line_total, sale.original_currency || 'USD')}
+                                                                    </td>
+                                                                </tr>
+                                                            );
+                                                        })}
                                                     </tbody>
                                                 </Table>
                                             ) : (

--- a/frontend/src/pages/SalesReportPage.js
+++ b/frontend/src/pages/SalesReportPage.js
@@ -4,6 +4,9 @@ import { Card, Button, Form, Row, Col, Spinner, Alert, Table, Collapse } from 'r
 import { formatCurrency } from '../utils/format';
 import { downloadBlobResponse } from '../utils/download';
 import '../styles/datatable.css';
+import { getBaseApiUrl, getImageInitial, resolveImageUrl } from '../utils/image';
+
+const BASE_API_URL = getBaseApiUrl();
 
 // Helper to get the first day of the current month
 const getFirstDayOfMonth = () => {
@@ -207,14 +210,35 @@ function SalesReportPage() {
                                                                         </tr>
                                                                     </thead>
                                                                     <tbody>
-                                                                        {sale.items.map(item => (
-                                                                            <tr key={item.id}>
-                                                                                <td>{item.product_name}</td>
-                                                                                <td>{item.quantity}</td>
-                                                                                <td>{formatCurrency(item.unit_price)}</td>
-                                                                                <td className="text-end">{formatCurrency(item.line_total)}</td>
-                                                                            </tr>
-                                                                        ))}
+                                                                        {sale.items.map(item => {
+                                                                            const productImage = resolveImageUrl(
+                                                                                item.product_image || item.product?.image,
+                                                                                BASE_API_URL
+                                                                            );
+                                                                            const imageInitial = getImageInitial(item.product_name);
+
+                                                                            return (
+                                                                                <tr key={item.id}>
+                                                                                    <td>
+                                                                                        <div className="product-name-cell">
+                                                                                            <div className="product-name-cell__image">
+                                                                                                {productImage ? (
+                                                                                                    <img src={productImage} alt={item.product_name} />
+                                                                                                ) : (
+                                                                                                    <span>{imageInitial}</span>
+                                                                                                )}
+                                                                                            </div>
+                                                                                            <div className="product-name-cell__info">
+                                                                                                <div className="product-name-cell__name">{item.product_name}</div>
+                                                                                            </div>
+                                                                                        </div>
+                                                                                    </td>
+                                                                                    <td>{item.quantity}</td>
+                                                                                    <td>{formatCurrency(item.unit_price)}</td>
+                                                                                    <td className="text-end">{formatCurrency(item.line_total)}</td>
+                                                                                </tr>
+                                                                            );
+                                                                        })}
                                                                     </tbody>
                                                                 </Table>
                                                             </Card.Body>

--- a/frontend/src/pages/SupplierDetailPage.js
+++ b/frontend/src/pages/SupplierDetailPage.js
@@ -1,6 +1,6 @@
 // frontend/src/pages/SupplierDetailPage.js
 
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import axiosInstance from '../utils/axiosInstance';
 import { Container, Card, Row, Col, Spinner, Alert, Button, Accordion, ButtonToolbar, Table } from 'react-bootstrap';
@@ -10,8 +10,9 @@ import SupplierPaymentModal from '../components/SupplierPaymentModal';
 import ActionMenu from '../components/ActionMenu';
 import '../styles/datatable.css';
 import '../styles/transaction-history.css';
+import { getBaseApiUrl, getImageInitial, resolveImageUrl } from '../utils/image';
 
-const API_BASE_URL = 'http://127.0.0.1:8000';
+const BASE_API_URL = getBaseApiUrl();
 
 function SupplierDetailPage() {
     const { id } = useParams();
@@ -279,16 +280,37 @@ function SupplierDetailPage() {
                                                             </tr>
                                                         </thead>
                                                         <tbody>
-                                                            {purchaseItems.map(item => (
-                                                                <tr key={item.id}>
-                                                                    <td>{item.product_name}</td>
-                                                                    <td>{item.quantity}</td>
-                                                                    <td>{formatCurrency(item.unit_price, purchaseCurrency)}</td>
-                                                                    <td className="text-end">
-                                                                        {formatCurrency(item.line_total, purchaseCurrency)}
-                                                                    </td>
-                                                                </tr>
-                                                            ))}
+                                                            {purchaseItems.map(item => {
+                                                                const productImage = resolveImageUrl(
+                                                                    item.product_image || item.product?.image,
+                                                                    BASE_API_URL
+                                                                );
+                                                                const imageInitial = getImageInitial(item.product_name);
+
+                                                                return (
+                                                                    <tr key={item.id}>
+                                                                        <td>
+                                                                            <div className="product-name-cell">
+                                                                                <div className="product-name-cell__image">
+                                                                                    {productImage ? (
+                                                                                        <img src={productImage} alt={item.product_name} />
+                                                                                    ) : (
+                                                                                        <span>{imageInitial}</span>
+                                                                                    )}
+                                                                                </div>
+                                                                                <div className="product-name-cell__info">
+                                                                                    <div className="product-name-cell__name">{item.product_name}</div>
+                                                                                </div>
+                                                                            </div>
+                                                                        </td>
+                                                                        <td>{item.quantity}</td>
+                                                                        <td>{formatCurrency(item.unit_price, purchaseCurrency)}</td>
+                                                                        <td className="text-end">
+                                                                            {formatCurrency(item.line_total, purchaseCurrency)}
+                                                                        </td>
+                                                                    </tr>
+                                                                );
+                                                            })}
                                                         </tbody>
                                                     </Table>
                                                 </Accordion.Body>
@@ -389,18 +411,39 @@ function SupplierDetailPage() {
                                                                 </th>
                                                             </tr>
                                                         </thead>
-                                                        <tbody>
-                                                            {saleItems.map(item => (
-                                                                <tr key={item.id}>
-                                                                    <td>{item.product_name}</td>
-                                                                    <td>{item.quantity}</td>
-                                                                    <td>{formatCurrency(item.unit_price, saleCurrency)}</td>
-                                                                    <td className="text-end">
-                                                                        {formatCurrency(item.line_total, saleCurrency)}
-                                                                    </td>
-                                                                </tr>
-                                                            ))}
-                                                        </tbody>
+                                                      <tbody>
+                                                          {saleItems.map(item => {
+                                                              const productImage = resolveImageUrl(
+                                                                  item.product_image || item.product?.image,
+                                                                  BASE_API_URL
+                                                              );
+                                                              const imageInitial = getImageInitial(item.product_name);
+
+                                                              return (
+                                                                  <tr key={item.id}>
+                                                                      <td>
+                                                                          <div className="product-name-cell">
+                                                                              <div className="product-name-cell__image">
+                                                                                  {productImage ? (
+                                                                                      <img src={productImage} alt={item.product_name} />
+                                                                                  ) : (
+                                                                                      <span>{imageInitial}</span>
+                                                                                  )}
+                                                                              </div>
+                                                                              <div className="product-name-cell__info">
+                                                                                  <div className="product-name-cell__name">{item.product_name}</div>
+                                                                              </div>
+                                                                          </div>
+                                                                      </td>
+                                                                      <td>{item.quantity}</td>
+                                                                      <td>{formatCurrency(item.unit_price, saleCurrency)}</td>
+                                                                      <td className="text-end">
+                                                                          {formatCurrency(item.line_total, saleCurrency)}
+                                                                      </td>
+                                                                  </tr>
+                                                              );
+                                                          })}
+                                                      </tbody>
                                                     </Table>
                                                 </Accordion.Body>
                                             </Accordion.Item>

--- a/frontend/src/pages/WarehouseDetailPage.js
+++ b/frontend/src/pages/WarehouseDetailPage.js
@@ -5,6 +5,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { Card, Table, Button, Form, Row, Col, Alert, Spinner } from 'react-bootstrap';
 import axiosInstance from '../utils/axiosInstance';
 import '../styles/datatable.css';
+import { getBaseApiUrl, getImageInitial, resolveImageUrl } from '../utils/image';
 
 function WarehouseDetailPage() {
     const { id } = useParams();
@@ -23,6 +24,7 @@ function WarehouseDetailPage() {
     const [transferError, setTransferError] = useState('');
     const [transferSuccess, setTransferSuccess] = useState('');
     const [transferring, setTransferring] = useState(false);
+    const baseApiUrl = useMemo(() => getBaseApiUrl(), []);
 
     const fetchWarehouse = async (showSpinner = true) => {
         if (showSpinner) {
@@ -240,13 +242,34 @@ function WarehouseDetailPage() {
                         </thead>
                         <tbody>
                             {warehouse.stocks && warehouse.stocks.length > 0 ? (
-                                warehouse.stocks.map(stock => (
-                                    <tr key={stock.id}>
-                                        <td>{stock.product_name}</td>
-                                        <td>{stock.sku || '—'}</td>
-                                        <td>{stock.quantity}</td>
-                                    </tr>
-                                ))
+                                warehouse.stocks.map(stock => {
+                                    const productImage = resolveImageUrl(
+                                        stock.product_image || stock.image,
+                                        baseApiUrl
+                                    );
+                                    const imageInitial = getImageInitial(stock.product_name);
+
+                                    return (
+                                        <tr key={stock.id}>
+                                            <td>
+                                                <div className="product-name-cell">
+                                                    <div className="product-name-cell__image">
+                                                        {productImage ? (
+                                                            <img src={productImage} alt={stock.product_name} />
+                                                        ) : (
+                                                            <span>{imageInitial}</span>
+                                                        )}
+                                                    </div>
+                                                    <div className="product-name-cell__info">
+                                                        <div className="product-name-cell__name">{stock.product_name}</div>
+                                                    </div>
+                                                </div>
+                                            </td>
+                                            <td>{stock.sku || '—'}</td>
+                                            <td>{stock.quantity}</td>
+                                        </tr>
+                                    );
+                                })
                             ) : (
                                 <tr>
                                     <td colSpan="3" className="data-table-empty">No inventory tracked in this warehouse.</td>

--- a/frontend/src/styles/datatable.css
+++ b/frontend/src/styles/datatable.css
@@ -169,3 +169,71 @@
 .data-table tbody td.text-center {
   text-align: center;
 }
+
+.product-name-cell {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.product-name-cell__image {
+  width: 48px;
+  height: 48px;
+  border-radius: 14px;
+  overflow: hidden;
+  background: linear-gradient(135deg, rgba(148, 163, 184, 0.25), rgba(226, 232, 240, 0.45));
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: #475569;
+  font-weight: 600;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  flex-shrink: 0;
+}
+
+.product-name-cell__image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.product-name-cell__info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  min-width: 0;
+}
+
+.product-name-cell__name {
+  font-weight: 600;
+  color: #1e293b;
+  line-height: 1.3;
+  word-break: break-word;
+}
+
+.product-name-cell__meta,
+.sale-items-table__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  font-size: 0.8rem;
+  color: #64748b;
+}
+
+.product-name-cell__meta span::before,
+.sale-items-table__meta span::before {
+  content: '';
+  display: inline-block;
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: currentColor;
+  margin-right: 0.35rem;
+}
+
+.product-name-cell__meta span:first-child::before,
+.sale-items-table__meta span:first-child::before {
+  display: none;
+}

--- a/frontend/src/styles/saleForm.css
+++ b/frontend/src/styles/saleForm.css
@@ -380,6 +380,12 @@
 
 .sale-items-table__product {
     display: flex;
+    align-items: flex-start;
+    gap: 0.75rem;
+}
+
+.sale-items-table__info {
+    display: flex;
     flex-direction: column;
     gap: 0.35rem;
 }
@@ -411,25 +417,7 @@
 }
 
 .sale-items-table__meta {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.75rem;
-    font-size: 0.8rem;
-    color: #64748b;
-}
-
-.sale-items-table__meta span::before {
-    content: '';
-    display: inline-block;
-    width: 4px;
-    height: 4px;
-    border-radius: 50%;
-    background: currentColor;
-    margin-right: 0.35rem;
-}
-
-.sale-items-table__meta span:first-child::before {
-    display: none;
+    gap: 0.6rem;
 }
 
 .sale-items-table__actions {

--- a/frontend/src/utils/image.js
+++ b/frontend/src/utils/image.js
@@ -1,0 +1,46 @@
+// frontend/src/utils/image.js
+
+import axiosInstance from './axiosInstance';
+
+let cachedBaseUrl = null;
+
+export const getBaseApiUrl = () => {
+    if (cachedBaseUrl !== null) {
+        return cachedBaseUrl;
+    }
+
+    const apiBase = axiosInstance.defaults.baseURL || '';
+    cachedBaseUrl = apiBase.replace(/\/?api\/?$/, '');
+    return cachedBaseUrl;
+};
+
+export const resolveImageUrl = (imagePath, baseUrl = getBaseApiUrl()) => {
+    if (!imagePath) {
+        return null;
+    }
+
+    if (/^https?:\/\//i.test(imagePath)) {
+        return imagePath;
+    }
+
+    const normalizedBase = (baseUrl || '').replace(/\/$/, '');
+    if (!normalizedBase) {
+        return imagePath;
+    }
+
+    const normalizedPath = imagePath.startsWith('/') ? imagePath : `/${imagePath}`;
+    return `${normalizedBase}${normalizedPath}`;
+};
+
+export const getImageInitial = (name) => {
+    if (!name) {
+        return '?';
+    }
+
+    const trimmed = name.trim();
+    if (!trimmed) {
+        return '?';
+    }
+
+    return trimmed.charAt(0).toUpperCase();
+};


### PR DESCRIPTION
## Summary
- add shared image helpers and styling to support product thumbnails
- render product images beside product names across sale, purchase, offer, and report tables
- include thumbnails in warehouse inventory listings for consistency

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da6a3aadcc8323a1a84d3dbaea6823