### PR TITLE
Reverse customer payment history order

### DIFF
--- a/frontend/src/pages/CustomerDetailPage.js
+++ b/frontend/src/pages/CustomerDetailPage.js
@@ -344,7 +344,7 @@ function CustomerDetailPage() {
                         <Card.Body className="p-0">
                             {payments.length > 0 ? (
                                 <Accordion alwaysOpen className="transaction-accordion">
-                                    {payments.map((payment, index) => {
+                                    {[...payments].reverse().map((payment, index) => {
                                         const paymentDate = new Date(payment.payment_date).toLocaleDateString();
                                         const paymentAmount =
                                             payment.converted_amount ??


### PR DESCRIPTION
## Summary
- reverse the iteration order for customer payment history so that editing actions show the most recent entries last first

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da72b427b88323895a89b3ca0a7831