### PR TITLE
Improve sidebar navigation scrolling behaviour

### DIFF
--- a/frontend/src/components/AppLayout.js
+++ b/frontend/src/components/AppLayout.js
@@ -159,6 +159,7 @@ function AppLayout({ children }) {
                     className="app-sidebar d-flex flex-column p-3"
                     style={{
                         width: sidebarWidth,
+                        height: '100vh',
                         minHeight: '100vh',
                         transition: 'width 0.3s',
                         position: 'fixed',

--- a/frontend/src/styles/theme.css
+++ b/frontend/src/styles/theme.css
@@ -39,6 +39,8 @@ body {
   color: var(--text-secondary);
   box-shadow: var(--shadow-sm);
   border-right: 1px solid var(--color-surface-muted);
+  overflow-y: auto;
+  max-height: 100vh;
 }
 
 .app-sidebar h4 {
@@ -87,6 +89,8 @@ body {
   flex-direction: column;
   gap: 0.35rem;
   box-shadow: inset 0 0 0 1px var(--color-surface-muted);
+  max-height: 60vh;
+  overflow-y: auto;
 }
 
 .sidebar-submenu-collapsed {
@@ -224,6 +228,10 @@ body {
 .offcanvas.app-sidebar .offcanvas-header {
   background: var(--color-surface);
   color: var(--text-primary);
+}
+
+.offcanvas.app-sidebar .offcanvas-body {
+  overflow-y: auto;
 }
 
 .offcanvas.app-sidebar .btn-close {


### PR DESCRIPTION
## Summary
- constrain the fixed sidebar to the viewport height so the navigation can scroll independently of the page content
- add overflow handling to the reports submenu to reveal all report links when expanded
- ensure the mobile offcanvas navigation body supports vertical scrolling as well

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68daa2804db08323b91a96f2cc3f9005