### PR TITLE
Adjust transaction history cards to size to content

### DIFF
--- a/frontend/src/pages/CustomerDetailPage.js
+++ b/frontend/src/pages/CustomerDetailPage.js
@@ -182,9 +182,9 @@ function CustomerDetailPage() {
             </Modal>
 
             {/* Transaction Lists */}
-            <Row className="g-4">
+            <Row className="g-4 align-items-start">
                 <Col md={6}>
-                    <Card className="transaction-history-card transaction-history-card--sales h-100">
+                    <Card className="transaction-history-card transaction-history-card--sales">
                         <Card.Header className="transaction-history-card__header">
                             <div>
                                 <span className="transaction-history-card__eyebrow">History</span>
@@ -310,7 +310,7 @@ function CustomerDetailPage() {
                     </Card>
                 </Col>
                 <Col md={6}>
-                    <Card className="transaction-history-card transaction-history-card--payments h-100">
+                    <Card className="transaction-history-card transaction-history-card--payments">
                         <Card.Header className="transaction-history-card__header">
                             <div>
                                 <span className="transaction-history-card__eyebrow">History</span>

--- a/frontend/src/pages/SupplierDetailPage.js
+++ b/frontend/src/pages/SupplierDetailPage.js
@@ -193,7 +193,7 @@ function SupplierDetailPage() {
             />
 
             {/* Transaction Lists */}
-            <Row className="g-4">
+            <Row className="g-4 align-items-start">
                 <Col md={6} className="d-flex flex-column gap-4">
                     <Card className="transaction-history-card transaction-history-card--purchases">
                         <Card.Header className="transaction-history-card__header">
@@ -460,7 +460,7 @@ function SupplierDetailPage() {
                     </Card>
                 </Col>
                 <Col md={6}>
-                    <Card className="transaction-history-card transaction-history-card--payments h-100">
+                    <Card className="transaction-history-card transaction-history-card--payments">
                         <Card.Header className="transaction-history-card__header">
                             <div>
                                 <span className="transaction-history-card__eyebrow">History</span>

--- a/frontend/src/styles/transaction-history.css
+++ b/frontend/src/styles/transaction-history.css
@@ -4,6 +4,9 @@
     overflow: hidden;
     background: linear-gradient(160deg, #f8fafc 0%, #ffffff 55%, #eef2ff 100%);
     box-shadow: 0 18px 40px rgba(15, 23, 42, 0.08);
+}
+
+.transaction-history-card--stretched {
     min-height: 100%;
 }
 


### PR DESCRIPTION
## Summary
- align the customer and supplier transaction history rows to start so cards stack from the top
- let the history cards size themselves by removing h-100 usage and scoping the stretch helper to an opt-in modifier

## Testing
- npm --prefix frontend run build

------
https://chatgpt.com/codex/tasks/task_e_68daaba026e88323a2fcfb920602c372