### PR TITLE
Fix purchase edit navigation

### DIFF
--- a/frontend/src/pages/EditPurchasePage.js
+++ b/frontend/src/pages/EditPurchasePage.js
@@ -14,7 +14,15 @@ function EditPurchasePage() {
     const navigate = useNavigate();
     const location = useLocation();
     const returnTo = location.state?.returnTo ?? null;
-    const fallbackDestination = returnTo || `/purchases/${id}`;
+
+    const navigateBackToOrigin = () => {
+        if (returnTo) {
+            navigate(returnTo, { replace: true });
+            return;
+        }
+
+        navigate('/purchases');
+    };
 
     // Data state
     const [suppliers, setSuppliers] = useState([]);
@@ -145,7 +153,7 @@ function EditPurchasePage() {
         };
         try {
             await axiosInstance.put(`/purchases/${id}/`, dataToSubmit);
-            navigate(fallbackDestination, { replace: Boolean(returnTo) });
+            navigateBackToOrigin();
         } catch (err) {
             console.error('Failed to update purchase:', err.response?.data);
             setError('Failed to update purchase. Please check all fields.');
@@ -264,7 +272,7 @@ function EditPurchasePage() {
                                     <Button
                                         variant="outline-secondary"
                                         type="button"
-                                        onClick={() => navigate(fallbackDestination)}
+                                        onClick={navigateBackToOrigin}
                                     >
                                         Cancel
                                     </Button>


### PR DESCRIPTION
## Summary
- ensure the edit purchase form navigates back to the originating page when saving or cancelling
- default back-navigation to the purchases list when no originating page is supplied

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db7f24e3888323a68a33e3096f7591