### PR TITLE
Ensure purchase edit returns to source page

### DIFF
--- a/frontend/src/pages/PurchaseDetailPage.js
+++ b/frontend/src/pages/PurchaseDetailPage.js
@@ -109,7 +109,15 @@ function PurchaseDetailPage() {
                         <h4 className="text-end mt-3">Total: {formatCurrency(purchase.total_amount, purchase.original_currency || 'USD')}</h4>
                     </Card.Body>
                     <Card.Footer className="text-end">
-                        <Button as={Link} to={`/purchases/${purchase.id}/edit`} variant="warning" className="me-2">Edit</Button>
+                        <Button
+                            as={Link}
+                            to={`/purchases/${purchase.id}/edit`}
+                            state={{ returnTo: `/purchases/${purchase.id}` }}
+                            variant="warning"
+                            className="me-2"
+                        >
+                            Edit
+                        </Button>
                         <Button variant="danger" onClick={handleDelete}>Delete</Button>
                     </Card.Footer>
                 </Card>


### PR DESCRIPTION
## Summary
- send the purchase detail URL in navigation state when opening the edit screen so the redirect returns to the originating page

## Testing
- not run (frontend change only)


------
https://chatgpt.com/codex/tasks/task_e_68dd6bd11e2c8323a14f5ad82fc30209