### PR TITLE
Fix purchase detail edit button navigation

### DIFF
--- a/frontend/src/pages/PurchaseDetailPage.js
+++ b/frontend/src/pages/PurchaseDetailPage.js
@@ -1,7 +1,7 @@
 // frontend/src/pages/PurchaseDetailPage.js
 
 import React, { useState, useEffect } from 'react';
-import { useParams, useNavigate, Link } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
 import axiosInstance from '../utils/axiosInstance';
 import { Card, Button, Spinner, Alert, Row, Col, Table } from 'react-bootstrap';
 import { formatCurrency } from '../utils/format';
@@ -110,11 +110,11 @@ function PurchaseDetailPage() {
                     </Card.Body>
                     <Card.Footer className="text-end">
                         <Button
-                            as={Link}
-                            to={`/purchases/${purchase.id}/edit`}
-                            state={{ returnTo: `/purchases/${purchase.id}` }}
                             variant="warning"
                             className="me-2"
+                            onClick={() => navigate(`/purchases/${purchase.id}/edit`, {
+                                state: { returnTo: `/purchases/${purchase.id}` },
+                            })}
                         >
                             Edit
                         </Button>


### PR DESCRIPTION
## Summary
- ensure the purchase detail edit button explicitly navigates to the edit page while preserving the return path

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd6fd2b1048323b0fc7867a7cc8d8c