### PR TITLE
Reuse purchase form for editing

### DIFF
--- a/frontend/src/pages/PurchaseDetailPage.js
+++ b/frontend/src/pages/PurchaseDetailPage.js
@@ -112,9 +112,27 @@ function PurchaseDetailPage() {
                         <Button
                             variant="warning"
                             className="me-2"
-                            onClick={() => navigate(`/purchases/${purchase.id}/edit`, {
-                                state: { returnTo: `/purchases/${purchase.id}` },
-                            })}
+                            onClick={() => {
+                                if (purchase.supplier) {
+                                    navigate(`/suppliers/${purchase.supplier}/new-purchase`, {
+                                        state: {
+                                            purchaseId: purchase.id,
+                                            returnTo: `/purchases/${purchase.id}`,
+                                        },
+                                    });
+                                } else if (purchase.customer) {
+                                    navigate(`/customers/${purchase.customer}/new-purchase`, {
+                                        state: {
+                                            purchaseId: purchase.id,
+                                            returnTo: `/purchases/${purchase.id}`,
+                                        },
+                                    });
+                                } else {
+                                    navigate(`/purchases/${purchase.id}/edit`, {
+                                        state: { returnTo: `/purchases/${purchase.id}` },
+                                    });
+                                }
+                            }}
                         >
                             Edit
                         </Button>

--- a/frontend/src/pages/SupplierDetailPage.js
+++ b/frontend/src/pages/SupplierDetailPage.js
@@ -257,8 +257,11 @@ function SupplierDetailPage() {
                                                                 {
                                                                     label: 'Edit Purchase',
                                                                     icon: <PencilSquare />,
-                                                                    onClick: () => navigate(`/purchases/${purchase.id}/edit`, {
-                                                                        state: { returnTo: `/suppliers/${id}` },
+                                                                    onClick: () => navigate(`/suppliers/${id}/new-purchase`, {
+                                                                        state: {
+                                                                            purchaseId: purchase.id,
+                                                                            returnTo: `/suppliers/${id}`,
+                                                                        },
                                                                     }),
                                                                 },
                                                                 {


### PR DESCRIPTION
## Summary
- route purchase edit actions back to the supplier/customer purchase form
- allow the purchase form to preload an existing purchase and send update requests
- keep the navigation consistent by returning to the originating page after save or cancel

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68df9cb7ba5883238980c341d40a32c0