### PR TITLE
Add PDF invoice generation and client printing flow

### DIFF
--- a/backend/api/invoice_pdf.py
+++ b/backend/api/invoice_pdf.py
@@ -1,15 +1,19 @@
+"""Utilities for generating PDF invoices."""
+
 from io import BytesIO
 from pathlib import Path
+from typing import IO
 
-from reportlab.lib.pagesizes import A4
-from reportlab.lib.units import mm
 from reportlab.lib import colors
-from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
-from reportlab.lib.enums import TA_RIGHT, TA_CENTER
+from reportlab.lib.enums import TA_CENTER, TA_RIGHT
+from reportlab.lib.pagesizes import A4
+from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
+from reportlab.lib.units import mm
 from reportlab.lib.utils import ImageReader
 from reportlab.pdfbase import pdfmetrics
 from reportlab.pdfbase.ttfonts import TTFont
-from reportlab.platypus import SimpleDocTemplate, Table, TableStyle, Paragraph, Spacer, Image
+from reportlab.platypus import (Image, Paragraph, SimpleDocTemplate, Spacer,
+                                Table, TableStyle)
 
 from .models import CompanyInfo, Sale
 
@@ -60,8 +64,9 @@ def _build_image_flowable(image_field, width, height, **image_kwargs):
 
     return ''
 
-def generate_invoice_pdf(sale):
-    """Generate a professional PDF invoice for the given Sale instance."""
+def generate_invoice_pdf(sale: Sale) -> IO[bytes]:
+    """Generate a professional PDF invoice for the given ``Sale`` instance."""
+
     buffer = BytesIO()
 
     _ensure_custom_fonts()
@@ -234,6 +239,5 @@ def generate_invoice_pdf(sale):
 
     # --- Build PDF ---
     doc.build(elements)
-    pdf = buffer.getvalue()
-    buffer.close()
-    return pdf
+    buffer.seek(0)
+    return buffer

--- a/backend/api/views/sales.py
+++ b/backend/api/views/sales.py
@@ -4,7 +4,7 @@ from datetime import date
 
 from django.db import transaction
 from django.db.models import F
-from django.http import HttpResponse
+from django.http import FileResponse, HttpResponse
 from rest_framework import serializers, status, viewsets
 from rest_framework.decorators import action, api_view, permission_classes
 from rest_framework.exceptions import NotFound
@@ -89,10 +89,12 @@ class SaleViewSet(viewsets.ModelViewSet):
         """Return a PDF representation of the sale invoice."""
 
         sale = self.get_object()
-        pdf_bytes = generate_invoice_pdf(sale)
+        pdf_buffer = generate_invoice_pdf(sale)
         filename = f"invoice_{sale.invoice_number or sale.id}.pdf"
-        response = HttpResponse(pdf_bytes, content_type='application/pdf')
-        response['Content-Disposition'] = f'attachment; filename="{filename}"'
+
+        response = FileResponse(pdf_buffer, content_type='application/pdf')
+        response['Content-Disposition'] = f'inline; filename="{filename}"'
+        response['Content-Length'] = str(len(pdf_buffer.getbuffer()))
         return response
 
 

--- a/frontend/src/pages/SaleDetailPage.js
+++ b/frontend/src/pages/SaleDetailPage.js
@@ -1,6 +1,6 @@
 // frontend/src/pages/SaleDetailPage.js
 
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useParams, useNavigate, Link } from 'react-router-dom';
 import axiosInstance from '../utils/axiosInstance';
 import { Card, Button, Spinner, Alert, Row, Col, Table } from 'react-bootstrap';
@@ -8,6 +8,15 @@ import AddPaymentModal from '../components/AddPaymentModal';
 import { getBaseCurrency, loadBaseCurrency } from '../config/currency';
 import '../styles/datatable.css';
 import { getBaseApiUrl, getImageInitial, resolveImageUrl } from '../utils/image';
+
+const extractFilenameFromDisposition = disposition => {
+    if (!disposition) {
+        return null;
+    }
+
+    const filenameMatch = /filename="?([^";]+)"?/i.exec(disposition);
+    return filenameMatch ? decodeURIComponent(filenameMatch[1]) : null;
+};
 
 const BASE_API_URL = getBaseApiUrl();
 
@@ -80,8 +89,10 @@ setCustomerCurrency(customerRes.data.currency || 'USD');
                 responseType: 'blob', // Important for handling binary data
             });
 
-            const filename = `invoice_${sale.invoice_number || sale.id}.pdf`;
-            const blobUrl = window.URL.createObjectURL(new Blob([response.data], { type: 'application/pdf' }));
+            const fallbackFilename = `invoice_${sale.invoice_number || sale.id}.pdf`;
+            const filename = extractFilenameFromDisposition(response.headers['content-disposition']) || fallbackFilename;
+            const blob = new Blob([response.data], { type: 'application/pdf' });
+            const blobUrl = window.URL.createObjectURL(blob);
 
             // Try to render the PDF in a new tab for printing.
             const pdfWindow = window.open('', '_blank');


### PR DESCRIPTION
## Summary
- wrap the invoice PDF generator with type hints and return a stream suitable for download
- expose a `sales/:id/invoice_pdf/` action that streams the generated PDF with inline disposition
- extend the sale detail page to request the PDF, parse filenames from the response, and open it for printing or downloading

## Testing
- `venv/bin/python manage.py test api.tests` *(fails: No such file or directory – Windows venv layout not usable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dfa83dbfe48323b52073ffd8b1b0da