### PR TITLE
Enforce authenticated access by default

### DIFF
--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -1,6 +1,7 @@
 """URL routing for the accounting API."""
 
 from django.urls import include, path
+from rest_framework.permissions import AllowAny
 from rest_framework.routers import DefaultRouter
 from rest_framework_nested import routers
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
@@ -52,8 +53,16 @@ suppliers_router = routers.NestedSimpleRouter(router, r'suppliers', lookup='supp
 suppliers_router.register(r'payments', SupplierPaymentViewSet, basename='supplier-payments')
 
 urlpatterns = [
-    path('token/', TokenObtainPairView.as_view(), name='get_token'),
-    path('token/refresh/', TokenRefreshView.as_view(), name='refresh_token'),
+    path(
+        'token/',
+        TokenObtainPairView.as_view(permission_classes=[AllowAny]),
+        name='get_token',
+    ),
+    path(
+        'token/refresh/',
+        TokenRefreshView.as_view(permission_classes=[AllowAny]),
+        name='refresh_token',
+    ),
     path('dashboard-summary/', dashboard_summary, name='dashboard-summary'),
     path('auth/register/', CreateUserView.as_view(), name='register'),
     path('reports/profit-loss/', profit_and_loss_report, name='profit-loss-report'),

--- a/backend/api/views/auth.py
+++ b/backend/api/views/auth.py
@@ -2,6 +2,7 @@
 
 from django.contrib.auth.models import User
 from rest_framework import generics
+from rest_framework.permissions import AllowAny
 
 from ..serializers import UserSerializer
 
@@ -11,3 +12,4 @@ class CreateUserView(generics.CreateAPIView):
 
     queryset = User.objects.all()
     serializer_class = UserSerializer
+    permission_classes = [AllowAny]

--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -159,6 +159,9 @@ REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': [
         'rest_framework_simplejwt.authentication.JWTAuthentication',
     ],
+    'DEFAULT_PERMISSION_CLASSES': [
+        'rest_framework.permissions.IsAuthenticated',
+    ],
 }
 
 


### PR DESCRIPTION
## Summary
- set DRF's default permission to require authenticated users across the API
- explicitly allow anonymous access for registration and JWT token endpoints to preserve public availability

## Testing
- `python manage.py test` *(fails: existing failures in dashboard summary metrics, invoice PDF currency output, and warehouse inventory uniqueness)*

------
https://chatgpt.com/codex/tasks/task_e_68e4c8db068c832391b419cdb294a284