### PR TITLE
Fix supplier sale payload target

### DIFF
--- a/frontend/src/pages/SaleFormPage.js
+++ b/frontend/src/pages/SaleFormPage.js
@@ -288,7 +288,11 @@ function SaleFormPage({
         } else if (isEditMode) {
             url = `/sales/${saleId}/`;
             method = 'put';
-            payload.customer_id = entityId;
+            if (isSupplierSale) {
+                payload.supplier_id = entityId;
+            } else {
+                payload.customer_id = entityId;
+            }
             payload.sale_date = saleDate;
             payload.invoice_date = invoiceDate;
             if (invoiceNumber) {
@@ -303,7 +307,11 @@ function SaleFormPage({
         } else {
             url = '/sales/';
             method = 'post';
-            payload.customer_id = entityId;
+            if (isSupplierSale) {
+                payload.supplier_id = entityId;
+            } else {
+                payload.customer_id = entityId;
+            }
             payload.sale_date = saleDate;
         }
 


### PR DESCRIPTION
## Summary
- ensure supplier-targeted sales requests include `supplier_id` instead of `customer_id`

## Testing
- npm test -- --watchAll=false *(fails: existing CustomerPaymentModal tests cannot find "Add New Payment")*


------
https://chatgpt.com/codex/tasks/task_e_68e4ccfc0b5c8323832be6fd32d3188f