### PR TITLE
Add consolidated inventory reporting

### DIFF
--- a/backend/api/tests/test_report_exports.py
+++ b/backend/api/tests/test_report_exports.py
@@ -9,7 +9,15 @@ from django.test import TestCase
 from openpyxl import load_workbook
 from rest_framework.test import APIClient
 
-from ..models import Customer, Expense, ExpenseCategory, Sale
+from ..models import (
+    Customer,
+    Expense,
+    ExpenseCategory,
+    Product,
+    Sale,
+    Warehouse,
+    WarehouseInventory,
+)
 
 
 class ReportExportTests(TestCase):
@@ -38,12 +46,32 @@ class ReportExportTests(TestCase):
         )
 
         category = ExpenseCategory.objects.create(name="Office", created_by=self.user)
-        Expense.objects.create(
+        self.expense = Expense.objects.create(
             category=category,
             amount=Decimal("40.00"),
+            original_amount=Decimal("40.00"),
             expense_date=date(2024, 1, 2),
             created_by=self.user,
         )
+        self.expense.refresh_from_db()
+
+        self.product = Product.objects.create(
+            name="Widget",
+            description="Test product",
+            sku="W-001",
+            purchase_price=Decimal("12.50"),
+            sale_price=Decimal("20.00"),
+            created_by=self.user,
+        )
+
+        self.default_warehouse = Warehouse.get_default(self.user)
+        WarehouseInventory.adjust_stock(self.product, self.default_warehouse, Decimal("5"))
+
+        self.secondary_warehouse = Warehouse.objects.create(
+            name="Secondary Warehouse",
+            created_by=self.user,
+        )
+        WarehouseInventory.adjust_stock(self.product, self.secondary_warehouse, Decimal("3"))
 
     def _assert_pdf_response(self, response):
         self.assertEqual(response.status_code, 200, response.content)
@@ -89,6 +117,18 @@ class ReportExportTests(TestCase):
         self._assert_pdf_response(response)
 
     def test_profit_loss_excel_contains_totals(self):
+        self.assertEqual(self.expense.amount, Decimal("40.00"))
+        json_response = self.client.get(
+            "/api/reports/profit-loss/",
+            {
+                "start_date": "2023-01-01",
+                "end_date": self.report_end_date,
+            },
+        )
+        payload = json_response.json()
+        self.assertAlmostEqual(float(payload["total_expenses"]), 40.0)
+        self.assertAlmostEqual(float(payload["net_profit"]), float(self.sale.total_amount) - 40.0)
+
         response = self.client.get(
             "/api/reports/profit-loss/",
             {
@@ -108,10 +148,20 @@ class ReportExportTests(TestCase):
 
         self.assertEqual(worksheet["A5"].value, "Revenue")
         self.assertAlmostEqual(worksheet["C5"].value, float(self.sale.total_amount))
-        self.assertEqual(worksheet["B7"].value, "Total Expenses")
-        self.assertAlmostEqual(worksheet["C7"].value, 40.0)
-        self.assertEqual(worksheet["A8"].value, "Summary")
-        self.assertAlmostEqual(worksheet["C8"].value, float(self.sale.total_amount) - 40.0)
+        rows = list(worksheet.iter_rows(values_only=True))
+        total_expenses_row = next(
+            (row for row in rows if row and len(row) > 2 and row[1] == "Total Expenses"),
+            None,
+        )
+        self.assertIsNotNone(total_expenses_row)
+        self.assertAlmostEqual(total_expenses_row[2], 40.0)
+
+        summary_row = next(
+            (row for row in rows if row and row[0] == "Summary"),
+            None,
+        )
+        self.assertIsNotNone(summary_row)
+        self.assertAlmostEqual(summary_row[2], float(self.sale.total_amount) - 40.0)
 
     def test_profit_loss_pdf_download(self):
         response = self.client.get(
@@ -170,6 +220,51 @@ class ReportExportTests(TestCase):
     def test_customer_balance_pdf_download(self):
         response = self.client.get(
             "/api/reports/customer-balances/",
+            {
+                "export_format": "pdf",
+            },
+        )
+
+        self._assert_pdf_response(response)
+
+    def test_inventory_report_json_includes_totals(self):
+        response = self.client.get("/api/reports/inventory/")
+
+        self.assertEqual(response.status_code, 200, response.content)
+        data = response.json()
+        product_row = next((item for item in data if item["id"] == self.product.id), None)
+        self.assertIsNotNone(product_row, data)
+        self.assertEqual(product_row["name"], self.product.name)
+        self.assertEqual(product_row["sku"], self.product.sku)
+        self.assertEqual(Decimal(str(product_row["stock_quantity"])), Decimal("8"))
+
+    def test_inventory_report_excel_contains_totals(self):
+        response = self.client.get(
+            "/api/reports/inventory/",
+            {
+                "export_format": "xlsx",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200, response.content)
+        self.assertEqual(
+            response["Content-Type"],
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        )
+        workbook = load_workbook(BytesIO(response.content))
+        worksheet = workbook.active
+
+        self.assertEqual(worksheet["A1"].value, "Inventory Report")
+        self.assertEqual(worksheet["B5"].value, self.product.name)
+        self.assertAlmostEqual(worksheet["E5"].value, 8.0)
+        self.assertAlmostEqual(worksheet["F5"].value, float(self.product.purchase_price))
+        self.assertAlmostEqual(worksheet["G5"].value, float(self.product.sale_price))
+        self.assertEqual(worksheet["D7"].value, "Totals")
+        self.assertAlmostEqual(worksheet["E7"].value, 8.0)
+
+    def test_inventory_report_pdf_download(self):
+        response = self.client.get(
+            "/api/reports/inventory/",
             {
                 "export_format": "pdf",
             },

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -18,7 +18,7 @@ from .views.customers import (
     customer_balance_report,
 )
 from .views.expenses import ExpenseCategoryViewSet, ExpenseViewSet, profit_and_loss_report
-from .views.products import ProductViewSet
+from .views.products import ProductViewSet, inventory_report
 from .views.purchases import PurchaseReturnViewSet, PurchaseViewSet
 from .views.sales import OfferViewSet, PaymentViewSet, SaleReturnViewSet, SaleViewSet, sales_report
 from .views.warehouses import WarehouseViewSet
@@ -68,6 +68,7 @@ urlpatterns = [
     path('reports/profit-loss/', profit_and_loss_report, name='profit-loss-report'),
     path('reports/customer-balances/', customer_balance_report, name='customer-balance-report'),
     path('reports/sales/', sales_report, name='sales-report'),
+    path('reports/inventory/', inventory_report, name='inventory-report'),
     path('', include(router.urls)),
     path('', include(sales_router.urls)),
     path('', include(customers_router.urls)),

--- a/backend/api/views/__init__.py
+++ b/backend/api/views/__init__.py
@@ -12,7 +12,7 @@ from .customers import (
     customer_balance_report,
 )
 from .expenses import ExpenseCategoryViewSet, ExpenseViewSet, profit_and_loss_report
-from .products import ProductViewSet
+from .products import ProductViewSet, inventory_report
 from .purchases import PurchaseReturnViewSet, PurchaseViewSet
 from .sales import (
     OfferViewSet,
@@ -49,4 +49,5 @@ __all__ = [
     'profit_and_loss_report',
     'customer_balance_report',
     'sales_report',
+    'inventory_report',
 ]

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -25,6 +25,7 @@ import ExpenseListPage from './pages/ExpenseListPage';
 import ProfitLossPage from './pages/ProfitLossPage';
 import SalesReportPage from './pages/SalesReportPage';
 import CustomerBalanceReportPage from './pages/CustomerBalanceReportPage';
+import InventoryReportPage from './pages/InventoryReportPage';
 import PurchaseFormPage from './pages/PurchaseFormPage';
 import EditSalePage from './pages/EditSalePage';
 import PurchaseListPage from './pages/PurchaseListPage';
@@ -89,6 +90,7 @@ function App() {
                   <Route path="reports/profit-loss" element={<ProfitLossPage />} />
                   <Route path="reports/sales" element={<SalesReportPage />} />
                   <Route path="reports/customer-balances" element={<CustomerBalanceReportPage />} />
+                  <Route path="reports/inventory" element={<InventoryReportPage />} />
                   <Route path="sales/:id/edit" element={<EditSalePage />} /> {/* <-- Add Route */}
                   <Route path="purchases" element={<PurchaseListPage />} /> {/* <-- Add Route */}
                   <Route path="purchases/:id" element={<PurchaseDetailPage />} /> {/* <-- Add Route */}

--- a/frontend/src/components/AppLayout.js
+++ b/frontend/src/components/AppLayout.js
@@ -135,6 +135,14 @@ function AppLayout({ children }) {
                             >
                                 Customer Balances
                             </NavLink>
+                            <NavLink
+                                to="/reports/inventory"
+                                className={({ isActive }) =>
+                                    `sidebar-submenu-link ${isActive ? 'active' : ''}`
+                                }
+                            >
+                                Inventory
+                            </NavLink>
                         </div>
                     )}
                 </div>

--- a/frontend/src/pages/InventoryReportPage.js
+++ b/frontend/src/pages/InventoryReportPage.js
@@ -1,0 +1,232 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import axiosInstance from '../utils/axiosInstance';
+import { Card, Spinner, Alert, Table, Button, Row, Col } from 'react-bootstrap';
+import { formatCurrency, formatNumber } from '../utils/format';
+import { downloadBlobResponse } from '../utils/download';
+import '../styles/datatable.css';
+
+const normaliseDecimal = (value) => {
+    if (typeof value === 'number') {
+        return Number.isFinite(value) ? value : 0;
+    }
+    if (typeof value === 'string') {
+        const parsed = Number(value);
+        return Number.isFinite(parsed) ? parsed : 0;
+    }
+    const parsed = Number(value ?? 0);
+    return Number.isFinite(parsed) ? parsed : 0;
+};
+
+function InventoryReportPage() {
+    const [reportData, setReportData] = useState([]);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState('');
+    const [downloadError, setDownloadError] = useState('');
+    const [exportingFormat, setExportingFormat] = useState(null);
+
+    const loadReport = async () => {
+        setLoading(true);
+        setError('');
+        setDownloadError('');
+        try {
+            const response = await axiosInstance.get('/reports/inventory/');
+            const data = Array.isArray(response.data) ? response.data : [];
+            setReportData(data);
+        } catch (err) {
+            console.error('Failed to load inventory report:', err);
+            setError('Could not load the inventory report. Please try again.');
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const downloadReport = async (format) => {
+        setDownloadError('');
+        setExportingFormat(format);
+        try {
+            const response = await axiosInstance.get('/reports/inventory/', {
+                params: { export_format: format },
+                responseType: 'blob',
+            });
+            const extension = format === 'pdf' ? 'pdf' : 'xlsx';
+            const fallbackName = `inventory-report.${extension}`;
+            downloadBlobResponse(response, fallbackName);
+        } catch (err) {
+            console.error('Failed to download inventory report:', err);
+            setDownloadError('Could not download the report. Please try again.');
+        } finally {
+            setExportingFormat(null);
+        }
+    };
+
+    useEffect(() => {
+        loadReport();
+    }, []);
+
+    const summary = useMemo(() => {
+        return reportData.reduce(
+            (acc, product) => {
+                const quantity = normaliseDecimal(product.stock_quantity);
+                const buyingPrice = normaliseDecimal(product.purchase_price);
+                const sellingPrice = normaliseDecimal(product.sale_price);
+
+                acc.totalItems += 1;
+                acc.totalQuantity += quantity;
+                acc.totalCost += quantity * buyingPrice;
+                acc.totalRevenue += quantity * sellingPrice;
+                return acc;
+            },
+            { totalItems: 0, totalQuantity: 0, totalCost: 0, totalRevenue: 0 }
+        );
+    }, [reportData]);
+
+    return (
+        <Card>
+            <Card.Header className="d-flex flex-wrap justify-content-between align-items-center gap-2">
+                <h4 className="mb-0">Inventory Report</h4>
+                <div className="d-flex flex-wrap gap-2">
+                    <Button
+                        variant="outline-secondary"
+                        onClick={() => downloadReport('xlsx')}
+                        disabled={loading || exportingFormat !== null}
+                    >
+                        {exportingFormat === 'xlsx' ? (
+                            <>
+                                <Spinner as="span" animation="border" size="sm" role="status" className="me-2" />
+                                Preparing...
+                            </>
+                        ) : (
+                            'Download Excel'
+                        )}
+                    </Button>
+                    <Button
+                        variant="outline-secondary"
+                        onClick={() => downloadReport('pdf')}
+                        disabled={loading || exportingFormat !== null}
+                    >
+                        {exportingFormat === 'pdf' ? (
+                            <>
+                                <Spinner as="span" animation="border" size="sm" role="status" className="me-2" />
+                                Preparing...
+                            </>
+                        ) : (
+                            'Download PDF'
+                        )}
+                    </Button>
+                    <Button
+                        variant="primary"
+                        onClick={loadReport}
+                        disabled={loading || exportingFormat !== null}
+                    >
+                        {loading ? (
+                            <>
+                                <Spinner as="span" animation="border" size="sm" role="status" className="me-2" />
+                                Refreshing
+                            </>
+                        ) : (
+                            'Refresh'
+                        )}
+                    </Button>
+                </div>
+            </Card.Header>
+            <Card.Body>
+                {error && <Alert variant="danger">{error}</Alert>}
+                {downloadError && <Alert variant="danger">{downloadError}</Alert>}
+
+                {loading && reportData.length === 0 ? (
+                    <div className="text-center py-5">
+                        <Spinner animation="border" role="status" />
+                    </div>
+                ) : (
+                    <>
+                        <Row className="mb-4 g-3">
+                            <Col md={3} sm={6}>
+                                <Card bg="primary" text="white" className="h-100">
+                                    <Card.Body>
+                                        <Card.Title className="text-uppercase fs-6">Total Items</Card.Title>
+                                        <div className="display-6">{summary.totalItems}</div>
+                                    </Card.Body>
+                                </Card>
+                            </Col>
+                            <Col md={3} sm={6}>
+                                <Card bg="info" text="white" className="h-100">
+                                    <Card.Body>
+                                        <Card.Title className="text-uppercase fs-6">Total Quantity</Card.Title>
+                                        <div className="display-6">{formatNumber(summary.totalQuantity)}</div>
+                                    </Card.Body>
+                                </Card>
+                            </Col>
+                            <Col md={3} sm={6}>
+                                <Card bg="secondary" text="white" className="h-100">
+                                    <Card.Body>
+                                        <Card.Title className="text-uppercase fs-6">Inventory Cost</Card.Title>
+                                        <div className="display-6">{formatCurrency(summary.totalCost)}</div>
+                                    </Card.Body>
+                                </Card>
+                            </Col>
+                            <Col md={3} sm={6}>
+                                <Card bg="success" text="white" className="h-100">
+                                    <Card.Body>
+                                        <Card.Title className="text-uppercase fs-6">Potential Revenue</Card.Title>
+                                        <div className="display-6">{formatCurrency(summary.totalRevenue)}</div>
+                                    </Card.Body>
+                                </Card>
+                            </Col>
+                        </Row>
+
+                        <div className="data-table-container">
+                            <Table responsive className="data-table">
+                                <thead>
+                                    <tr>
+                                        <th>#</th>
+                                        <th>Item Name</th>
+                                        <th>Description</th>
+                                        <th>Item Code</th>
+                                        <th className="text-end">Quantity</th>
+                                        <th className="text-end">Buying Price</th>
+                                        <th className="text-end">Selling Price</th>
+                                        <th className="text-end">Total Cost</th>
+                                        <th className="text-end">Potential Revenue</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {reportData.length === 0 ? (
+                                        <tr>
+                                            <td colSpan="9" className="text-center py-4 text-muted">
+                                                No inventory data available.
+                                            </td>
+                                        </tr>
+                                    ) : (
+                                        reportData.map((product, index) => {
+                                            const quantity = normaliseDecimal(product.stock_quantity);
+                                            const buyingPrice = normaliseDecimal(product.purchase_price);
+                                            const sellingPrice = normaliseDecimal(product.sale_price);
+                                            const totalCost = quantity * buyingPrice;
+                                            const totalRevenue = quantity * sellingPrice;
+
+                                            return (
+                                                <tr key={product.id || index}>
+                                                    <td>{index + 1}</td>
+                                                    <td>{product.name}</td>
+                                                    <td>{product.description || <span className="text-muted">No description</span>}</td>
+                                                    <td>{product.sku || <span className="text-muted">—</span>}</td>
+                                                    <td className="text-end">{formatNumber(quantity)}</td>
+                                                    <td className="text-end">{formatCurrency(buyingPrice)}</td>
+                                                    <td className="text-end">{formatCurrency(sellingPrice)}</td>
+                                                    <td className="text-end">{formatCurrency(totalCost)}</td>
+                                                    <td className="text-end">{formatCurrency(totalRevenue)}</td>
+                                                </tr>
+                                            );
+                                        })
+                                    )}
+                                </tbody>
+                            </Table>
+                        </div>
+                    </>
+                )}
+            </Card.Body>
+        </Card>
+    );
+}
+
+export default InventoryReportPage;


### PR DESCRIPTION
## Summary
- add Excel and PDF generators for an all-warehouse inventory report and expose it via the API
- surface the new inventory report endpoint in Django routing and extend automated export coverage
- provide a frontend inventory report page with download buttons and dashboard-style summaries

## Testing
- python3 manage.py test api.tests.test_report_exports -v 2

------
https://chatgpt.com/codex/tasks/task_e_68e4ea77450883238fdc1227e930f1b6