### PR TITLE
Revamp activity log timeline UI

### DIFF
--- a/frontend/src/pages/ActivityPage.js
+++ b/frontend/src/pages/ActivityPage.js
@@ -1,86 +1,310 @@
-import React, { useState, useEffect } from 'react';
-import { Card, ListGroup, Spinner, Alert, Form, Button } from 'react-bootstrap';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+    Alert,
+    Badge,
+    Button,
+    Card,
+    Col,
+    Form,
+    Row,
+    Spinner
+} from 'react-bootstrap';
+import { Calendar3, ClockHistory } from 'react-bootstrap-icons';
+import dayjs from 'dayjs';
+import relativeTime from 'dayjs/plugin/relativeTime';
 import axiosInstance from '../utils/axiosInstance';
+import '../styles/activity-log.css';
+
+dayjs.extend(relativeTime);
+
+const formatDateLabel = (date) => {
+    const parsed = dayjs(date);
+    return parsed.isValid() ? parsed.format('dddd, MMM D, YYYY') : 'Select a date';
+};
+
+const formatTime = (timestamp) => {
+    const parsed = dayjs(timestamp);
+    return parsed.isValid() ? parsed.format('h:mm A') : '--';
+};
+
+const formatRelativeTime = (timestamp) => {
+    const parsed = dayjs(timestamp);
+    return parsed.isValid() ? parsed.fromNow() : '';
+};
+
+const getInitials = (value = '') => {
+    const trimmed = value.trim();
+    if (!trimmed) {
+        return '??';
+    }
+
+    const parts = trimmed.split(/\s+/).slice(0, 2);
+    return parts.map((part) => part[0]).join('').toUpperCase();
+};
 
 function ActivityPage() {
     const [activities, setActivities] = useState([]);
+    const [availableDates, setAvailableDates] = useState([]);
     const [selectedDate, setSelectedDate] = useState('');
-    const [loading, setLoading] = useState(true);
+    const [inputDate, setInputDate] = useState('');
+    const [initialLoading, setInitialLoading] = useState(true);
+    const [timelineLoading, setTimelineLoading] = useState(false);
     const [error, setError] = useState('');
 
-    const fetchByDate = async (date) => {
+    const fetchByDate = useCallback(async (date, options = {}) => {
+        const { skipSpinner = false } = options;
+
+        if (!date) {
+            setActivities([]);
+            return;
+        }
+
+        setError('');
+
         try {
-            setLoading(true);
-            const response = await axiosInstance.get(`/activities/?date=${date}`);
-            setActivities(response.data);
+            if (!skipSpinner) {
+                setTimelineLoading(true);
+            }
+
+            const response = await axiosInstance.get('/activities/', { params: { date } });
+            const data = Array.isArray(response.data) ? response.data : [];
+            setActivities(data);
         } catch (err) {
             console.error('Failed to fetch activities:', err);
             setError('Could not load activities.');
+            setActivities([]);
         } finally {
-            setLoading(false);
+            if (!skipSpinner) {
+                setTimelineLoading(false);
+            }
         }
-    };
+    }, []);
 
     useEffect(() => {
-        const init = async () => {
+        const initialiseActivities = async () => {
             try {
+                setInitialLoading(true);
                 const response = await axiosInstance.get('/activities/');
-                if (response.data.length > 0) {
-                    const latestDate = response.data[0].timestamp.split('T')[0];
+                const data = Array.isArray(response.data) ? response.data : [];
+
+                const uniqueDates = Array.from(
+                    new Set(
+                        data
+                            .map((item) => item.timestamp && item.timestamp.split('T')[0])
+                            .filter(Boolean)
+                    )
+                ).sort((a, b) => dayjs(b).valueOf() - dayjs(a).valueOf());
+
+                setAvailableDates(uniqueDates);
+
+                if (uniqueDates.length > 0) {
+                    const latestDate = uniqueDates[0];
                     setSelectedDate(latestDate);
-                    await fetchByDate(latestDate);
+                    setInputDate(latestDate);
+
+                    const todaysActivities = data.filter(
+                        (item) => item.timestamp && item.timestamp.startsWith(latestDate)
+                    );
+
+                    if (todaysActivities.length > 0) {
+                        setActivities(todaysActivities);
+                    } else {
+                        await fetchByDate(latestDate, { skipSpinner: true });
+                    }
                 } else {
                     setActivities([]);
-                    setLoading(false);
                 }
+
+                setError('');
             } catch (err) {
                 console.error('Failed to fetch activities:', err);
                 setError('Could not load activities.');
-                setLoading(false);
+                setActivities([]);
+            } finally {
+                setInitialLoading(false);
             }
         };
-        init();
-    }, []);
 
-    const handleShow = () => {
-        if (selectedDate) {
-            fetchByDate(selectedDate);
+        initialiseActivities();
+    }, [fetchByDate]);
+
+    const handleSubmit = (event) => {
+        event.preventDefault();
+
+        if (!inputDate) {
+            return;
+        }
+
+        setSelectedDate(inputDate);
+        fetchByDate(inputDate);
+    };
+
+    const handleQuickSelect = (event) => {
+        const value = event.target.value;
+        setInputDate(value);
+
+        if (value) {
+            setSelectedDate(value);
+            fetchByDate(value);
+        } else {
+            setActivities([]);
         }
     };
 
-    if (loading) {
-        return <Spinner animation="border" />;
-    }
+    const isLoading = initialLoading || timelineLoading;
+    const activityCount = activities.length;
+    const formattedSelectedDate = formatDateLabel(selectedDate);
 
-    if (error) {
-        return <Alert variant="danger">{error}</Alert>;
-    }
+    const uniqueUserCount = useMemo(() => {
+        const uniqueUsers = new Set();
+
+        activities.forEach((activity) => {
+            const user = (activity.user || '').trim();
+            uniqueUsers.add(user || 'Unknown user');
+        });
+
+        return uniqueUsers.size;
+    }, [activities]);
 
     return (
-        <div>
-            <h2 className="mb-4">Activity Log</h2>
-            <Form className="mb-3 d-flex align-items-end">
-                <Form.Group controlId="activityDate">
-                    <Form.Label>Date</Form.Label>
-                    <Form.Control type="date" value={selectedDate} onChange={e => setSelectedDate(e.target.value)} />
-                </Form.Group>
-                <Button className="ms-2" onClick={handleShow}>Show</Button>
-            </Form>
-            <Card>
-                <Card.Header>
-                    <h5>Activities</h5>
+        <div className="activity-page">
+            <div className="activity-page__header">
+                <div>
+                    <h2 className="activity-page__title mb-1">Activity Log</h2>
+                    <p className="activity-page__subtitle mb-0 text-muted">
+                        Track the latest actions recorded across your workspace.
+                    </p>
+                </div>
+                <div className="activity-insight-card">
+                    <div className="activity-insight-icon">
+                        <ClockHistory size={22} />
+                    </div>
+                    <div>
+                        <span className="activity-insight-label">Entries</span>
+                        <h4 className="activity-insight-value mb-0">{activityCount}</h4>
+                        <div className="activity-insight-meta">
+                            <Badge bg="light" text="dark">
+                                {uniqueUserCount} {uniqueUserCount === 1 ? 'user' : 'users'}
+                            </Badge>
+                            <span>{formattedSelectedDate}</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            {error && !isLoading && (
+                <Alert variant="danger" className="mb-3">
+                    {error}
+                </Alert>
+            )}
+
+            <Card className="activity-filter-card">
+                <Card.Body>
+                    <Form onSubmit={handleSubmit} className="activity-filter-form">
+                        <Row className="g-3 align-items-end">
+                            <Col xs={12} md={4}>
+                                <Form.Label htmlFor="activity-date" className="fw-semibold">
+                                    Filter by date
+                                </Form.Label>
+                                <Form.Control
+                                    id="activity-date"
+                                    type="date"
+                                    value={inputDate}
+                                    max={availableDates[0] || ''}
+                                    onChange={(event) => setInputDate(event.target.value)}
+                                />
+                            </Col>
+                            {availableDates.length > 0 && (
+                                <Col xs={12} md={4}>
+                                    <Form.Label className="fw-semibold">Quick select</Form.Label>
+                                    <Form.Select value={selectedDate} onChange={handleQuickSelect}>
+                                        {availableDates.map((dateOption) => (
+                                            <option key={dateOption} value={dateOption}>
+                                                {formatDateLabel(dateOption)}
+                                            </option>
+                                        ))}
+                                    </Form.Select>
+                                </Col>
+                            )}
+                            <Col xs={12} md={4} className="text-md-end">
+                                <Button
+                                    type="submit"
+                                    variant="primary"
+                                    className="px-4"
+                                    disabled={isLoading || !inputDate}
+                                >
+                                    {isLoading ? 'Loading…' : 'Show activity'}
+                                </Button>
+                            </Col>
+                        </Row>
+                    </Form>
+                </Card.Body>
+            </Card>
+
+            <Card className="activity-timeline-card">
+                <Card.Header className="activity-timeline-card__header">
+                    <div>
+                        <span className="activity-timeline-card__eyebrow">Timeline</span>
+                        <h5 className="mb-0">Updates for {formattedSelectedDate}</h5>
+                    </div>
+                    <Badge bg="primary" className="activity-timeline-count">
+                        {activityCount} {activityCount === 1 ? 'entry' : 'entries'}
+                    </Badge>
                 </Card.Header>
-                <ListGroup variant="flush">
-                    {activities.map(activity => (
-                        <ListGroup.Item key={activity.id}>
-                            <div><strong>{activity.user}</strong> {activity.description}</div>
-                            <small className="text-muted">{new Date(activity.timestamp).toLocaleTimeString()}</small>
-                        </ListGroup.Item>
-                    ))}
-                    {activities.length === 0 && (
-                        <ListGroup.Item>No activities found.</ListGroup.Item>
+                <Card.Body>
+                    {isLoading ? (
+                        <div className="activity-timeline-empty text-center py-5">
+                            <Spinner animation="border" />
+                            <p className="text-muted mt-3 mb-0">Loading activity…</p>
+                        </div>
+                    ) : error ? (
+                        <Alert variant="danger" className="mb-0">
+                            {error}
+                        </Alert>
+                    ) : activityCount > 0 ? (
+                        <div className="activity-timeline">
+                            {activities.map((activity, index) => {
+                                const userName = activity.user || 'Unknown user';
+                                const description = activity.description || 'No additional details provided.';
+                                const timestamp = activity.timestamp;
+                                const timeLabel = formatTime(timestamp);
+                                const relativeLabel = formatRelativeTime(timestamp);
+                                const key = activity.id ?? `${timestamp}-${index}`;
+
+                                return (
+                                    <div className="activity-timeline__item" key={key}>
+                                        <div className="activity-timeline__card">
+                                            <div className="activity-timeline__avatar">{getInitials(userName)}</div>
+                                            <div className="activity-timeline__content">
+                                                <div className="activity-timeline__content-header">
+                                                    <div>
+                                                        <span className="activity-timeline__user">{userName}</span>
+                                                        <p className="activity-timeline__description mb-1">{description}</p>
+                                                    </div>
+                                                    {relativeLabel && (
+                                                        <span className="activity-timeline__relative">{relativeLabel}</span>
+                                                    )}
+                                                </div>
+                                                <div className="activity-timeline__meta">
+                                                    <ClockHistory size={16} />
+                                                    <span>{timeLabel}</span>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                );
+                            })}
+                        </div>
+                    ) : (
+                        <div className="activity-empty-state text-center py-5">
+                            <div className="activity-empty-icon">
+                                <Calendar3 size={24} />
+                            </div>
+                            <h6 className="mt-3 mb-1">No activity recorded</h6>
+                            <p className="text-muted mb-0">Try choosing a different date or check back later.</p>
+                        </div>
                     )}
-                </ListGroup>
+                </Card.Body>
             </Card>
         </div>
     );

--- a/frontend/src/styles/activity-log.css
+++ b/frontend/src/styles/activity-log.css
@@ -1,0 +1,283 @@
+.activity-page {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.activity-page__header {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+@media (min-width: 768px) {
+  .activity-page__header {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+}
+
+.activity-page__title {
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.activity-page__subtitle {
+  color: rgba(15, 23, 42, 0.7);
+}
+
+.activity-insight-card {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 1rem 1.25rem;
+  border-radius: 1.25rem;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.12), rgba(37, 99, 235, 0.04));
+  border: 1px solid rgba(59, 130, 246, 0.12);
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.12);
+  min-width: 260px;
+}
+
+.activity-insight-icon {
+  display: inline-flex;
+  width: 48px;
+  height: 48px;
+  border-radius: 16px;
+  align-items: center;
+  justify-content: center;
+  color: #1d4ed8;
+  background: rgba(37, 99, 235, 0.12);
+}
+
+.activity-insight-label {
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  color: rgba(15, 23, 42, 0.55);
+}
+
+.activity-insight-value {
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.activity-insight-meta {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+  color: rgba(15, 23, 42, 0.7);
+}
+
+.activity-insight-meta .badge {
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.15);
+  color: #1d4ed8;
+  font-weight: 600;
+  padding: 0.35rem 0.75rem;
+}
+
+.activity-filter-card {
+  border: none;
+  border-radius: 1.5rem;
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.05), rgba(15, 23, 42, 0.02));
+  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.12);
+}
+
+.activity-filter-card .card-body {
+  padding: 1.5rem;
+}
+
+.activity-filter-form label {
+  color: #0f172a;
+  font-size: 0.9rem;
+}
+
+.activity-filter-form .form-control,
+.activity-filter-form .form-select {
+  border-radius: 0.9rem;
+}
+
+.activity-timeline-card {
+  border: none;
+  border-radius: 1.5rem;
+  box-shadow: 0 22px 45px rgba(15, 23, 42, 0.12);
+}
+
+.activity-timeline-card__header {
+  border: none;
+  background: transparent;
+  padding: 1.5rem 1.5rem 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.activity-timeline-card__eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: rgba(15, 23, 42, 0.6);
+}
+
+.activity-timeline-count {
+  border-radius: 999px;
+  padding: 0.45rem 1rem;
+  font-weight: 600;
+}
+
+.activity-timeline-card .card-body {
+  padding: 0 1.5rem 1.5rem;
+}
+
+.activity-timeline {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+  padding-left: 1.75rem;
+}
+
+.activity-timeline::before {
+  content: '';
+  position: absolute;
+  top: 0.25rem;
+  bottom: 0.25rem;
+  left: 0.45rem;
+  width: 2px;
+  background: linear-gradient(180deg, rgba(59, 130, 246, 0.4), rgba(99, 102, 241, 0.16));
+}
+
+.activity-timeline__item {
+  position: relative;
+  padding-left: 0.25rem;
+}
+
+.activity-timeline__item::before {
+  content: '';
+  position: absolute;
+  top: 0.95rem;
+  left: -1.1rem;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: #ffffff;
+  border: 3px solid rgba(37, 99, 235, 0.8);
+  box-shadow: 0 0 0 6px rgba(37, 99, 235, 0.12);
+}
+
+.activity-timeline__card {
+  display: flex;
+  gap: 1rem;
+  padding: 1rem 1.25rem;
+  border-radius: 1.25rem;
+  background: linear-gradient(135deg, rgba(241, 245, 249, 0.9), rgba(255, 255, 255, 0.95));
+  border: 1px solid rgba(148, 163, 184, 0.15);
+  box-shadow: 0 14px 30px rgba(15, 23, 42, 0.12);
+}
+
+.activity-timeline__avatar {
+  width: 48px;
+  height: 48px;
+  border-radius: 16px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.18), rgba(191, 219, 254, 0.85));
+  color: #1e293b;
+  font-weight: 700;
+  font-size: 0.95rem;
+}
+
+.activity-timeline__content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.activity-timeline__content-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.activity-timeline__user {
+  display: block;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.activity-timeline__description {
+  color: rgba(15, 23, 42, 0.72);
+  font-size: 0.95rem;
+}
+
+.activity-timeline__relative {
+  font-size: 0.85rem;
+  color: rgba(37, 99, 235, 0.85);
+  font-weight: 600;
+}
+
+.activity-timeline__meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+  color: rgba(15, 23, 42, 0.65);
+}
+
+.activity-timeline__meta svg {
+  color: #2563eb;
+}
+
+.activity-timeline-empty {
+  color: rgba(15, 23, 42, 0.6);
+}
+
+.activity-empty-state {
+  max-width: 360px;
+  margin: 0 auto;
+}
+
+.activity-empty-icon {
+  width: 56px;
+  height: 56px;
+  border-radius: 18px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(37, 99, 235, 0.12);
+  color: #1d4ed8;
+}
+
+.activity-empty-state h6 {
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.activity-empty-state p {
+  color: rgba(15, 23, 42, 0.6);
+}
+
+@media (max-width: 575.98px) {
+  .activity-filter-card .card-body {
+    padding: 1.25rem;
+  }
+
+  .activity-insight-card {
+    width: 100%;
+  }
+
+  .activity-timeline {
+    padding-left: 1.25rem;
+  }
+
+  .activity-timeline__item::before {
+    left: -0.9rem;
+  }
+}


### PR DESCRIPTION
## Summary
- redesign the activity log page with insights, quick filters, and a timeline presentation for entries
- add a dedicated stylesheet that styles the new timeline layout, insight card, and responsive adjustments

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e61a53dc8483239f0c3a0545d83020