### PR TITLE
Refactor currency conversion into shared helper

### DIFF
--- a/backend/api/services/__init__.py
+++ b/backend/api/services/__init__.py
@@ -1,0 +1,1 @@
+"""Service utilities for reusable domain logic."""

--- a/backend/api/services/currency.py
+++ b/backend/api/services/currency.py
@@ -1,0 +1,108 @@
+"""Shared currency conversion helpers used across finance models."""
+from __future__ import annotations
+
+from decimal import Decimal, InvalidOperation
+from typing import Any, Optional, Sequence
+
+from ..exchange_rates import get_exchange_rate
+
+TWOPLACES = Decimal("0.01")
+
+
+def _coerce_decimal(value: Any, fallback: Decimal) -> Decimal:
+    """Return ``value`` as :class:`~decimal.Decimal` or ``fallback`` if invalid."""
+
+    if isinstance(value, Decimal):
+        return value
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, TypeError):
+        return fallback
+
+
+def to_decimal(value: Any, default: Any = "0") -> Decimal:
+    """Normalise ``value`` into :class:`~decimal.Decimal` with a fallback."""
+
+    default_decimal = default if isinstance(default, Decimal) else _coerce_decimal(default, Decimal("0"))
+    if value in (None, ""):
+        return default_decimal
+    return _coerce_decimal(value, default_decimal)
+
+
+def normalise_currency(value: Optional[str], *fallbacks: Optional[str], default: str = "USD") -> str:
+    """Return an upper-cased ISO currency code using provided fallbacks."""
+
+    candidates: Sequence[Optional[str]] = (value,) + fallbacks + (default,)
+    for candidate in candidates:
+        if not candidate:
+            continue
+        code = str(candidate).strip().upper()
+        if code:
+            return code
+    raise ValueError("Unable to determine currency code")
+
+
+def resolve_exchange_rate(
+    from_currency: str,
+    to_currency: str,
+    manual_rate: Any = None,
+    *,
+    default: Any = None,
+) -> Decimal:
+    """Resolve an exchange rate, honouring manual overrides and fallbacks."""
+
+    from_code = normalise_currency(from_currency)
+    to_code = normalise_currency(to_currency)
+    if from_code == to_code:
+        return Decimal("1")
+
+    manual_decimal: Optional[Decimal] = None
+    if manual_rate not in (None, ""):
+        manual_decimal = to_decimal(manual_rate, default="0")
+        if manual_decimal > 0:
+            return manual_decimal
+
+    try:
+        return get_exchange_rate(from_code, to_code)
+    except Exception:
+        if manual_decimal is not None and manual_decimal > 0:
+            return manual_decimal
+        if default not in (None, ""):
+            fallback_rate = to_decimal(default, default="1")
+            if fallback_rate > 0:
+                return fallback_rate
+        raise
+
+
+def calculate_converted_amount(
+    amount: Any,
+    rate: Any,
+    *,
+    exponent: Decimal = TWOPLACES,
+) -> Decimal:
+    """Return ``amount`` converted using ``rate`` and quantised to two places."""
+
+    amount_decimal = to_decimal(amount)
+    rate_decimal = to_decimal(rate, default="1")
+    return (amount_decimal * rate_decimal).quantize(exponent)
+
+
+def convert_amount(
+    amount: Any,
+    from_currency: str,
+    to_currency: str,
+    *,
+    manual_rate: Any = None,
+    default_rate: Any = None,
+    exponent: Decimal = TWOPLACES,
+) -> tuple[Decimal, Decimal]:
+    """Return the resolved rate and converted amount for a currency pair."""
+
+    rate = resolve_exchange_rate(
+        from_currency,
+        to_currency,
+        manual_rate=manual_rate,
+        default=default_rate,
+    )
+    converted = calculate_converted_amount(amount, rate, exponent=exponent)
+    return rate, converted

--- a/backend/api/tests/test_payment_currency_conversion.py
+++ b/backend/api/tests/test_payment_currency_conversion.py
@@ -5,10 +5,11 @@ from unittest.mock import patch
 from django.contrib.auth.models import User
 from django.test import TestCase
 
-from ..models import Customer, BankAccount, Payment
+from ..models import Customer, Supplier, BankAccount, Payment, Expense
+from ..services.currency import convert_amount
 
 
-class PaymentCurrencyConversionTest(TestCase):
+class CurrencyConversionServiceTest(TestCase):
     def setUp(self):
         self.user = User.objects.create_user(username="payer", password="pw")
         self.customer = Customer.objects.create(
@@ -17,13 +18,19 @@ class PaymentCurrencyConversionTest(TestCase):
             open_balance=Decimal("125.00"),
             created_by=self.user,
         )
+        self.supplier = Supplier.objects.create(
+            name="Bob",
+            currency="GBP",
+            open_balance=Decimal("0"),
+            created_by=self.user,
+        )
         self.account = BankAccount.objects.create(
             name="Euro Account",
             currency="EUR",
             created_by=self.user,
         )
 
-    @patch("api.models.get_exchange_rate", return_value=Decimal("1.25"))
+    @patch("api.services.currency.get_exchange_rate", return_value=Decimal("1.25"))
     def test_foreign_currency_payment_converts_and_updates_balances(self, mock_rate):
         payment = Payment.objects.create(
             customer=self.customer,
@@ -47,7 +54,7 @@ class PaymentCurrencyConversionTest(TestCase):
         self.assertEqual(self.customer.open_balance, Decimal("0.00"))
         mock_rate.assert_not_called()
 
-    @patch("api.models.get_exchange_rate")
+    @patch("api.services.currency.get_exchange_rate")
     def test_account_currency_mismatch_converts_balance(self, mock_rate):
         def side_effect(from_curr, to_curr):
             rates = {
@@ -84,3 +91,55 @@ class PaymentCurrencyConversionTest(TestCase):
         self.assertEqual(lira_account.balance, Decimal("3500.00"))
         self.assertEqual(self.customer.open_balance, Decimal("0.00"))
         self.assertEqual(mock_rate.call_count, 2)
+
+    @patch("api.services.currency.get_exchange_rate")
+    def test_expense_conversion_for_supplier_and_account(self, mock_rate):
+        def side_effect(from_curr, to_curr):
+            rates = {
+                ("USD", "GBP"): Decimal("0.80"),
+                ("USD", "EUR"): Decimal("0.90"),
+            }
+            return rates[(from_curr, to_curr)]
+
+        mock_rate.side_effect = side_effect
+
+        expense_account = BankAccount.objects.create(
+            name="Expense Account", currency="EUR", created_by=self.user
+        )
+
+        expense = Expense.objects.create(
+            amount=Decimal("0"),
+            original_amount=Decimal("200.00"),
+            original_currency="USD",
+            expense_date=date.today(),
+            description="Travel",
+            account=expense_account,
+            supplier=self.supplier,
+            created_by=self.user,
+        )
+
+        expense.refresh_from_db()
+        self.supplier.refresh_from_db()
+        expense_account.refresh_from_db()
+
+        self.assertEqual(expense.exchange_rate, Decimal("0.80"))
+        self.assertEqual(expense.converted_amount, Decimal("160.00"))
+        self.assertEqual(expense.account_exchange_rate, Decimal("0.90"))
+        self.assertEqual(expense.account_converted_amount, Decimal("180.00"))
+        self.assertEqual(expense.amount, Decimal("180.00"))
+        self.assertEqual(expense_account.balance, Decimal("-180.00"))
+        self.assertEqual(self.supplier.open_balance, Decimal("-160.00"))
+        self.assertEqual(mock_rate.call_count, 2)
+
+    @patch("api.services.currency.get_exchange_rate", side_effect=RuntimeError("down"))
+    def test_convert_amount_falls_back_to_default_rate(self, mock_rate):
+        rate, converted = convert_amount(
+            Decimal("50"),
+            "USD",
+            "EUR",
+            default_rate=Decimal("1.20"),
+        )
+
+        self.assertEqual(rate, Decimal("1.20"))
+        self.assertEqual(converted, Decimal("60.00"))
+        mock_rate.assert_called_once_with("USD", "EUR")


### PR DESCRIPTION
## Summary
- add a shared currency service providing normalization, rate resolution, and conversion helpers
- refactor Payment and Expense models to rely on the shared helper for currency defaults and amount conversions
- expand currency conversion tests to cover both payments and expenses along with fallback behaviours

## Testing
- python3 manage.py test api.tests.test_payment_currency_conversion

------
https://chatgpt.com/codex/tasks/task_e_68e63d6ea5908323875a88274ead8227