### PR TITLE
Refactor sale form into modular components with dedicated hook

### DIFF
--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -22,6 +22,7 @@ jest.mock('axios', () => ({
       request: { use: jest.fn() },
       response: { use: jest.fn() },
     },
+    defaults: { baseURL: '' },
   }),
 }));
 

--- a/frontend/src/components/CustomerPaymentModal.test.js
+++ b/frontend/src/components/CustomerPaymentModal.test.js
@@ -7,6 +7,7 @@ jest.mock('../utils/axiosInstance', () => ({
   get: jest.fn(),
   post: jest.fn(),
   put: jest.fn(),
+  defaults: { baseURL: '' },
 }));
 
 describe('CustomerPaymentModal', () => {
@@ -47,14 +48,14 @@ describe('CustomerPaymentModal', () => {
 
   test('renders correctly for a new payment', async () => {
     render(<CustomerPaymentModal {...defaultProps} />);
-    await screen.findByText('Add New Payment');
+    await screen.findByText('Record Payment');
     expect(screen.getByLabelText(/^Amount$/)).toHaveValue(null);
   });
 
   test('shows exchange rate fields when payment currency and account currency differ', async () => {
     render(<CustomerPaymentModal {...defaultProps} />);
 
-    await screen.findByText('Add New Payment');
+    await screen.findByText('Record Payment');
 
     fireEvent.change(screen.getByLabelText('Account'), { target: { value: '2' } });
 
@@ -82,7 +83,7 @@ describe('CustomerPaymentModal', () => {
 
   test('hides exchange rate fields when payment and account currencies are the same', async () => {
     render(<CustomerPaymentModal {...defaultProps} />);
-    await screen.findByText('Add New Payment');
+    await screen.findByText('Record Payment');
 
     fireEvent.change(screen.getByLabelText('Account'), { target: { value: '1' } });
 
@@ -93,7 +94,7 @@ describe('CustomerPaymentModal', () => {
 
   test('submits correct data when creating a new payment with currency conversion', async () => {
     render(<CustomerPaymentModal {...defaultProps} />);
-    await screen.findByText('Add New Payment');
+    await screen.findByText('Record Payment');
 
     fireEvent.change(screen.getByLabelText('Account'), { target: { value: '2' } });
     fireEvent.change(screen.getByLabelText('Currency'), { target: { value: 'USD' } });

--- a/frontend/src/components/sales/SaleCustomerSelector.js
+++ b/frontend/src/components/sales/SaleCustomerSelector.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import { Alert, Card, Col, Form, Row } from 'react-bootstrap';
+
+function SaleCustomerSelector({
+    customerOptions,
+    selectedCustomerId,
+    onChange,
+    isLoading,
+    error,
+    onDismissError,
+}) {
+    return (
+        <Card className="sale-form__selection-card mb-4">
+            <Card.Body>
+                <Row className="align-items-end g-3">
+                    <Col md={8}>
+                        <Form.Group controlId="saleCustomer">
+                            <Form.Label>Select Customer</Form.Label>
+                            <Form.Select
+                                value={selectedCustomerId || ''}
+                                onChange={(event) => {
+                                    const value = event.target.value;
+                                    onChange(value ? Number(value) : null);
+                                }}
+                                disabled={isLoading}
+                            >
+                                <option value="">Choose a customer...</option>
+                                {customerOptions.map((option) => (
+                                    <option key={option.id} value={option.id}>
+                                        {option.name}
+                                    </option>
+                                ))}
+                            </Form.Select>
+                        </Form.Group>
+                    </Col>
+                    <Col md={4}>
+                        <div className="text-muted small">
+                            {isLoading ? 'Loading customers...' : 'Select a customer to start a new sale.'}
+                        </div>
+                    </Col>
+                </Row>
+                {error && (
+                    <Alert variant="danger" className="mt-3" onClose={onDismissError} dismissible>
+                        {error}
+                    </Alert>
+                )}
+            </Card.Body>
+        </Card>
+    );
+}
+
+export default SaleCustomerSelector;

--- a/frontend/src/components/sales/SaleCustomerSelector.test.js
+++ b/frontend/src/components/sales/SaleCustomerSelector.test.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import SaleCustomerSelector from './SaleCustomerSelector';
+
+describe('SaleCustomerSelector', () => {
+    const baseProps = {
+        customerOptions: [
+            { id: 1, name: 'Acme Corp' },
+            { id: 2, name: 'Globex' },
+        ],
+        selectedCustomerId: null,
+        onChange: jest.fn(),
+        isLoading: false,
+        error: null,
+        onDismissError: jest.fn(),
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('displays loading text when fetching customers', () => {
+        render(<SaleCustomerSelector {...baseProps} isLoading />);
+        expect(screen.getByText('Loading customers...')).toBeInTheDocument();
+    });
+
+    it('calls onChange with numeric value when a customer is selected', () => {
+        render(<SaleCustomerSelector {...baseProps} />);
+        fireEvent.change(screen.getByLabelText('Select Customer'), { target: { value: '2' } });
+        expect(baseProps.onChange).toHaveBeenCalledWith(2);
+    });
+
+    it('renders error message and allows dismissing it', () => {
+        render(<SaleCustomerSelector {...baseProps} error="Failed to load" />);
+        expect(screen.getByText('Failed to load')).toBeInTheDocument();
+        fireEvent.click(screen.getByRole('button', { name: /close/i }));
+        expect(baseProps.onDismissError).toHaveBeenCalled();
+    });
+});

--- a/frontend/src/components/sales/SaleLineItemsTable.js
+++ b/frontend/src/components/sales/SaleLineItemsTable.js
@@ -1,0 +1,180 @@
+import React from 'react';
+import { Alert, Badge, Button, Card, Table } from 'react-bootstrap';
+import { PencilSquare, Plus, Trash } from 'react-bootstrap-icons';
+import ProductSearchSelect from '../ProductSearchSelect';
+import { getImageInitial, resolveImageUrl } from '../../utils/image';
+
+function SaleLineItemsTable({
+    isOffer,
+    products,
+    lineItems,
+    warehouses,
+    hasWarehouses,
+    formError,
+    onDismissFormError,
+    formatCurrency,
+    onQuickProductSelect,
+    onNewLine,
+    quickSearchKey,
+    onEditItem,
+    onRemoveItem,
+    baseApiUrl,
+    getProductById,
+}) {
+    return (
+        <Card className="sale-form__items-card">
+            <Card.Header>
+                <div className="sale-form__items-header">
+                    <div>
+                        <h5 className="mb-0">Products &amp; Services</h5>
+                        <small className="text-muted">
+                            Add items from your catalog to this {isOffer ? 'offer' : 'sale'}.
+                        </small>
+                    </div>
+                    <div className="sale-form__quick-add">
+                        <ProductSearchSelect
+                            key={quickSearchKey}
+                            products={products}
+                            value={null}
+                            onSelect={onQuickProductSelect}
+                            placeholder="Search products to add"
+                            imageBaseUrl={baseApiUrl}
+                        />
+                        <Button
+                            type="button"
+                            className="mt-2 mt-sm-0"
+                            variant="outline-primary"
+                            onClick={onNewLine}
+                            disabled={!hasWarehouses}
+                        >
+                            <Plus className="me-1" /> New Line
+                        </Button>
+                    </div>
+                </div>
+            </Card.Header>
+            <Card.Body>
+                {!hasWarehouses && (
+                    <Alert variant="warning" className="mb-3">
+                        No warehouses available. Please create a warehouse before recording sales.
+                    </Alert>
+                )}
+                {formError && (
+                    <Alert variant="danger" className="mb-3" onClose={onDismissFormError} dismissible>
+                        {formError}
+                    </Alert>
+                )}
+                <div className="table-responsive">
+                    <Table hover borderless className="sale-items-table align-middle">
+                        <thead>
+                            <tr>
+                                <th>Product</th>
+                                <th>Warehouse</th>
+                                <th className="text-center">Stock</th>
+                                <th className="text-center">Quantity</th>
+                                <th className="text-end">Unit Price</th>
+                                <th className="text-center">Discount</th>
+                                <th className="text-end">Line Total</th>
+                                <th className="text-end">Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {lineItems.length === 0 && (
+                                <tr>
+                                    <td colSpan={8} className="text-center text-muted py-4">
+                                        Add products using the search above to build this {isOffer ? 'offer' : 'sale'}.
+                                    </td>
+                                </tr>
+                            )}
+                            {lineItems.map((item, index) => {
+                                const product = getProductById(item.product_id);
+                                const warehouse = warehouses.find((w) => w.id === Number(item.warehouse_id));
+                                const warehouseQuantity = product?.warehouse_quantities?.find(
+                                    (stock) => stock.warehouse_id === Number(item.warehouse_id)
+                                );
+                                const availableStock = warehouseQuantity ? Number(warehouseQuantity.quantity) : null;
+                                const discountLabel = item.discount ? `${Number(item.discount).toFixed(2)}%` : '—';
+                                const lineTotal = Number(item.quantity) * Number(item.unit_price || 0);
+                                const resolvedImage = resolveImageUrl(product?.image, baseApiUrl);
+                                const imageInitial = getImageInitial(product?.name);
+                                const metaDetails = [];
+
+                                if (item.note) {
+                                    metaDetails.push(<span key="note">Note: {item.note}</span>);
+                                }
+
+                                return (
+                                    <tr key={`${item.product_id}-${index}`}>
+                                        <td>
+                                            <div className="sale-items-table__product product-name-cell">
+                                                <div className="product-name-cell__image">
+                                                    {resolvedImage ? (
+                                                        <img src={resolvedImage} alt={product?.name || 'Product preview'} />
+                                                    ) : (
+                                                        <span>{imageInitial}</span>
+                                                    )}
+                                                </div>
+                                                <div className="sale-items-table__info product-name-cell__info product-name-cell__body">
+                                                    <div className="product-name-cell__header">
+                                                        <div className="sale-items-table__name product-name-cell__name">
+                                                            {product?.name || 'Unnamed product'}
+                                                        </div>
+                                                        {product?.sku && (
+                                                            <span className="product-name-cell__badge">SKU {product.sku}</span>
+                                                        )}
+                                                    </div>
+                                                    {metaDetails.length > 0 && (
+                                                        <div className="sale-items-table__meta product-name-cell__meta">
+                                                            {metaDetails}
+                                                        </div>
+                                                    )}
+                                                </div>
+                                            </div>
+                                        </td>
+                                        <td>
+                                            {warehouse ? <span>{warehouse.name}</span> : <span className="text-muted">No warehouse</span>}
+                                        </td>
+                                        <td className="text-center">
+                                            {product ? (
+                                                <Badge bg={availableStock && availableStock > 0 ? 'success' : 'danger'}>
+                                                    {availableStock !== null ? `${availableStock}` : 'No data'}
+                                                </Badge>
+                                            ) : (
+                                                <span className="text-muted">Select a product</span>
+                                            )}
+                                        </td>
+                                        <td className="text-center">{Number(item.quantity)}</td>
+                                        <td className="text-end">{formatCurrency(item.unit_price)}</td>
+                                        <td className="text-center">{discountLabel}</td>
+                                        <td className="text-end">{formatCurrency(lineTotal)}</td>
+                                        <td className="text-end">
+                                            <div className="sale-items-table__actions">
+                                                <Button
+                                                    variant="outline-secondary"
+                                                    size="sm"
+                                                    onClick={() => onEditItem(index)}
+                                                    aria-label="Edit line item"
+                                                >
+                                                    <PencilSquare />
+                                                </Button>
+                                                <Button
+                                                    variant="outline-danger"
+                                                    size="sm"
+                                                    onClick={() => onRemoveItem(index)}
+                                                    aria-label="Remove line item"
+                                                >
+                                                    <Trash />
+                                                </Button>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                );
+                            })}
+                        </tbody>
+                    </Table>
+                </div>
+            </Card.Body>
+        </Card>
+    );
+}
+
+export default SaleLineItemsTable;

--- a/frontend/src/components/sales/SaleLineItemsTable.test.js
+++ b/frontend/src/components/sales/SaleLineItemsTable.test.js
@@ -1,0 +1,94 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import SaleLineItemsTable from './SaleLineItemsTable';
+
+jest.mock('../ProductSearchSelect', () => (props) => (
+    <button type="button" onClick={() => props.onSelect && props.onSelect({ id: 99, sale_price: 42 })}>
+        Product Search
+    </button>
+));
+
+jest.mock('../../utils/image', () => ({
+    getImageInitial: () => 'W',
+    resolveImageUrl: () => null,
+}));
+
+describe('SaleLineItemsTable', () => {
+    const baseProps = {
+        isOffer: false,
+        products: [
+            {
+                id: 1,
+                name: 'Widget',
+                sale_price: 50,
+                sku: 'W-1',
+                warehouse_quantities: [{ warehouse_id: 1, quantity: 5 }],
+                image: null,
+            },
+        ],
+        lineItems: [],
+        warehouses: [{ id: 1, name: 'Main Warehouse' }],
+        hasWarehouses: true,
+        formError: null,
+        onDismissFormError: jest.fn(),
+        formatCurrency: (value) => `$${value}`,
+        onQuickProductSelect: jest.fn(),
+        onNewLine: jest.fn(),
+        quickSearchKey: 0,
+        onEditItem: jest.fn(),
+        onRemoveItem: jest.fn(),
+        baseApiUrl: 'http://localhost',
+        getProductById: (id) => ({
+            id: 1,
+            name: 'Widget',
+            sale_price: 50,
+            sku: 'W-1',
+            warehouse_quantities: [{ warehouse_id: 1, quantity: 5 }],
+            image: null,
+        }),
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('renders empty state when there are no line items', () => {
+        render(<SaleLineItemsTable {...baseProps} />);
+        expect(
+            screen.getByText('Add products using the search above to build this sale.')
+        ).toBeInTheDocument();
+    });
+
+    it('renders line items and triggers edit/remove callbacks', () => {
+        const props = {
+            ...baseProps,
+            lineItems: [
+                { product_id: 1, quantity: 2, unit_price: 25, discount: 0, warehouse_id: 1, note: 'Urgent' },
+            ],
+        };
+        render(<SaleLineItemsTable {...props} />);
+
+        expect(screen.getByText('Widget')).toBeInTheDocument();
+        expect(screen.getByText('$25')).toBeInTheDocument();
+        expect(screen.getByText('$50')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Edit line item' }));
+        expect(props.onEditItem).toHaveBeenCalledWith(0);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Remove line item' }));
+        expect(props.onRemoveItem).toHaveBeenCalledWith(0);
+    });
+
+    it('shows form errors and allows dismissing them', () => {
+        render(<SaleLineItemsTable {...baseProps} formError="Validation failed" />);
+        expect(screen.getByText('Validation failed')).toBeInTheDocument();
+        fireEvent.click(screen.getByRole('button', { name: /close/i }));
+        expect(baseProps.onDismissFormError).toHaveBeenCalled();
+    });
+
+    it('invokes new line handler when button clicked', () => {
+        render(<SaleLineItemsTable {...baseProps} />);
+        fireEvent.click(screen.getByRole('button', { name: /new line/i }));
+        expect(baseProps.onNewLine).toHaveBeenCalled();
+    });
+});

--- a/frontend/src/components/sales/SaleSidebarSummary.js
+++ b/frontend/src/components/sales/SaleSidebarSummary.js
@@ -1,0 +1,157 @@
+import React from 'react';
+import { Button, Card, Col, Form, Row, Stack } from 'react-bootstrap';
+
+function SaleSidebarSummary({
+    isEditMode,
+    isOffer,
+    customer,
+    allowCustomerSwitch,
+    customerOptions,
+    selectedCustomerId,
+    onCustomerChange,
+    isLoadingCustomerOptions,
+    documentNumber,
+    onDocumentNumberChange,
+    saleDate,
+    onSaleDateChange,
+    invoiceDate,
+    onInvoiceDateChange,
+    invoiceNumber,
+    onInvoiceNumberChange,
+    description,
+    onDescriptionChange,
+    totals,
+    formatCurrency,
+    hasWarehouses,
+    hasLineItems,
+    isSubmitting,
+    primaryActionLabel,
+    onCancel,
+}) {
+    return (
+        <Card className="sale-form__sidebar-card">
+            <Card.Header>
+                <div className="sale-form__sidebar-title">
+                    <div className="sale-form__sidebar-label">
+                        {isEditMode ? 'Edit Sale' : isOffer ? 'Offer' : 'Sale'} Summary
+                    </div>
+                    <div className="sale-form__sidebar-entity">{customer.name}</div>
+                </div>
+            </Card.Header>
+            <Card.Body>
+                {allowCustomerSwitch && (
+                    <Row className="gy-3 mb-1">
+                        <Col xs={12}>
+                            <Form.Group controlId="saleEditorCustomer">
+                                <Form.Label>Customer</Form.Label>
+                                <Form.Select
+                                    value={selectedCustomerId || ''}
+                                    onChange={(event) => {
+                                        const value = event.target.value;
+                                        onCustomerChange(value ? Number(value) : null);
+                                    }}
+                                    disabled={isLoadingCustomerOptions}
+                                    required
+                                >
+                                    <option value="">Select a customer</option>
+                                    {customerOptions.map((option) => (
+                                        <option key={option.id} value={option.id}>
+                                            {option.name}
+                                        </option>
+                                    ))}
+                                </Form.Select>
+                            </Form.Group>
+                        </Col>
+                    </Row>
+                )}
+                <div className="sale-form__entity-meta">
+                    {customer.phone && <span>{customer.phone}</span>}
+                    {customer.email && <span>{customer.email}</span>}
+                    <span>{customer.currency} account</span>
+                </div>
+                <Row className="gy-3 mt-1">
+                    <Col xs={12}>
+                        <Form.Group controlId="documentNumber">
+                            <Form.Label>Document No</Form.Label>
+                            <Form.Control
+                                type="text"
+                                value={documentNumber}
+                                placeholder="Auto"
+                                onChange={(event) => onDocumentNumberChange(event.target.value)}
+                            />
+                        </Form.Group>
+                    </Col>
+                    <Col md={6}>
+                        <Form.Group controlId="saleDate">
+                            <Form.Label>{isOffer ? 'Offer Date' : 'Sale Date'}</Form.Label>
+                            <Form.Control
+                                type="date"
+                                value={saleDate}
+                                onChange={(event) => onSaleDateChange(event.target.value)}
+                            />
+                        </Form.Group>
+                    </Col>
+                    <Col md={6}>
+                        <Form.Group controlId="invoiceDate">
+                            <Form.Label>Invoice Date</Form.Label>
+                            <Form.Control
+                                type="date"
+                                value={invoiceDate}
+                                onChange={(event) => onInvoiceDateChange(event.target.value)}
+                            />
+                        </Form.Group>
+                    </Col>
+                    <Col md={6}>
+                        <Form.Group controlId="invoiceNumber">
+                            <Form.Label>Invoice No</Form.Label>
+                            <Form.Control
+                                type="text"
+                                value={invoiceNumber}
+                                placeholder="Auto"
+                                onChange={(event) => onInvoiceNumberChange(event.target.value)}
+                            />
+                        </Form.Group>
+                    </Col>
+                    <Col xs={12}>
+                        <Form.Group controlId="description">
+                            <Form.Label>Description</Form.Label>
+                            <Form.Control
+                                as="textarea"
+                                rows={3}
+                                value={description}
+                                onChange={(event) => onDescriptionChange(event.target.value)}
+                                placeholder="Optional notes about this transaction"
+                            />
+                        </Form.Group>
+                    </Col>
+                </Row>
+                <div className="sale-form__summary mt-4">
+                    <div className="sale-form__summary-row">
+                        <span>Subtotal</span>
+                        <span>{formatCurrency(totals.base)}</span>
+                    </div>
+                    <div className="sale-form__summary-row">
+                        <span>Discount</span>
+                        <span>{formatCurrency(totals.discount)}</span>
+                    </div>
+                    <div className="sale-form__summary-row sale-form__summary-row--strong">
+                        <span>Net Total</span>
+                        <span>{formatCurrency(totals.net)}</span>
+                    </div>
+                </div>
+            </Card.Body>
+            <Card.Footer>
+                <Stack gap={2}>
+                    <Button type="submit" variant="success" disabled={!hasWarehouses || !hasLineItems || isSubmitting}>
+                        {primaryActionLabel}
+                    </Button>
+                    <Button variant="outline-secondary" onClick={onCancel} type="button">
+                        Cancel
+                    </Button>
+                </Stack>
+            </Card.Footer>
+        </Card>
+    );
+}
+
+export default SaleSidebarSummary;

--- a/frontend/src/components/sales/SaleSidebarSummary.test.js
+++ b/frontend/src/components/sales/SaleSidebarSummary.test.js
@@ -1,0 +1,68 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import SaleSidebarSummary from './SaleSidebarSummary';
+
+describe('SaleSidebarSummary', () => {
+    const formatCurrency = jest.fn((value) => `$${value}`);
+    const baseProps = {
+        isEditMode: false,
+        isOffer: false,
+        customer: { id: 1, name: 'Acme Corp', currency: 'USD', phone: '123', email: 'info@acme.test' },
+        allowCustomerSwitch: true,
+        customerOptions: [
+            { id: 1, name: 'Acme Corp' },
+            { id: 2, name: 'Globex' },
+        ],
+        selectedCustomerId: 1,
+        onCustomerChange: jest.fn(),
+        isLoadingCustomerOptions: false,
+        documentNumber: 'INV-1',
+        onDocumentNumberChange: jest.fn(),
+        saleDate: '2023-01-01',
+        onSaleDateChange: jest.fn(),
+        invoiceDate: '2023-01-02',
+        onInvoiceDateChange: jest.fn(),
+        invoiceNumber: '100',
+        onInvoiceNumberChange: jest.fn(),
+        description: 'Test sale',
+        onDescriptionChange: jest.fn(),
+        totals: { base: 100, discount: 10, net: 90 },
+        formatCurrency,
+        hasWarehouses: true,
+        hasLineItems: true,
+        isSubmitting: false,
+        primaryActionLabel: 'Save Sale',
+        onCancel: jest.fn(),
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('renders summary totals using provided formatter', () => {
+        render(<SaleSidebarSummary {...baseProps} />);
+        expect(formatCurrency).toHaveBeenCalledWith(100);
+        expect(formatCurrency).toHaveBeenCalledWith(10);
+        expect(formatCurrency).toHaveBeenCalledWith(90);
+        expect(screen.getByText('Save Sale')).toBeEnabled();
+    });
+
+    it('calls handlers when customer changes and cancel is clicked', () => {
+        render(<SaleSidebarSummary {...baseProps} />);
+        fireEvent.change(screen.getByLabelText('Customer'), { target: { value: '2' } });
+        expect(baseProps.onCustomerChange).toHaveBeenCalledWith(2);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+        expect(baseProps.onCancel).toHaveBeenCalled();
+    });
+
+    it('disables primary action when there are no line items or warehouses', () => {
+        const { rerender } = render(
+            <SaleSidebarSummary {...baseProps} hasLineItems={false} />
+        );
+        expect(screen.getByRole('button', { name: 'Save Sale' })).toBeDisabled();
+
+        rerender(<SaleSidebarSummary {...baseProps} hasWarehouses={false} />);
+        expect(screen.getByRole('button', { name: 'Save Sale' })).toBeDisabled();
+    });
+});

--- a/frontend/src/components/sales/useSaleItemModal.js
+++ b/frontend/src/components/sales/useSaleItemModal.js
@@ -1,0 +1,51 @@
+import { useCallback, useReducer } from 'react';
+
+const initialState = {
+    show: false,
+    index: null,
+    initialItem: null,
+};
+
+function reducer(state, action) {
+    switch (action.type) {
+        case 'OPEN_CREATE':
+            return {
+                show: true,
+                index: null,
+                initialItem: action.payload || null,
+            };
+        case 'OPEN_EDIT':
+            return {
+                show: true,
+                index: action.payload.index,
+                initialItem: action.payload.item,
+            };
+        case 'CLOSE':
+            return initialState;
+        default:
+            return state;
+    }
+}
+
+export default function useSaleItemModal() {
+    const [state, dispatch] = useReducer(reducer, initialState);
+
+    const openCreate = useCallback((defaultItem = null) => {
+        dispatch({ type: 'OPEN_CREATE', payload: defaultItem });
+    }, []);
+
+    const openEdit = useCallback((index, item) => {
+        dispatch({ type: 'OPEN_EDIT', payload: { index, item } });
+    }, []);
+
+    const close = useCallback(() => {
+        dispatch({ type: 'CLOSE' });
+    }, []);
+
+    return {
+        state,
+        openCreate,
+        openEdit,
+        close,
+    };
+}

--- a/frontend/src/components/sales/useSaleItemModal.test.js
+++ b/frontend/src/components/sales/useSaleItemModal.test.js
@@ -1,0 +1,30 @@
+import { act, renderHook } from '@testing-library/react';
+import useSaleItemModal from './useSaleItemModal';
+
+describe('useSaleItemModal', () => {
+    it('opens create modal with default item', () => {
+        const { result } = renderHook(() => useSaleItemModal());
+
+        act(() => {
+            result.current.openCreate({ product_id: 1 });
+        });
+
+        expect(result.current.state).toEqual({ show: true, index: null, initialItem: { product_id: 1 } });
+    });
+
+    it('opens edit modal and closes it', () => {
+        const { result } = renderHook(() => useSaleItemModal());
+
+        act(() => {
+            result.current.openEdit(2, { product_id: 5 });
+        });
+
+        expect(result.current.state).toEqual({ show: true, index: 2, initialItem: { product_id: 5 } });
+
+        act(() => {
+            result.current.close();
+        });
+
+        expect(result.current.state).toEqual({ show: false, index: null, initialItem: null });
+    });
+});

--- a/frontend/src/hooks/useSaleFormData.js
+++ b/frontend/src/hooks/useSaleFormData.js
@@ -1,0 +1,103 @@
+import { useCallback, useEffect, useState } from 'react';
+import axiosInstance from '../utils/axiosInstance';
+
+const DEFAULT_ERROR_MESSAGE = 'Failed to fetch sale details. Please try again.';
+
+export default function useSaleFormData({
+    entityId,
+    isSupplierSale,
+    onBeforeFetch = null,
+    onEntityCleared = null,
+}) {
+    const [entity, setEntity] = useState(null);
+    const [products, setProducts] = useState([]);
+    const [warehouses, setWarehouses] = useState([]);
+    const [isLoading, setIsLoading] = useState(false);
+    const [error, setError] = useState(null);
+
+    const loadEntityData = useCallback(
+        async (targetEntityId, isActiveRef) => {
+            if (!targetEntityId) {
+                setEntity(null);
+                setProducts([]);
+                setWarehouses([]);
+                setError(null);
+                return;
+            }
+
+            if (onBeforeFetch) {
+                onBeforeFetch();
+            }
+
+            setIsLoading(true);
+            setError(null);
+
+            try {
+                const [entityResponse, productsResponse, warehousesResponse] = await Promise.all([
+                    axiosInstance.get(isSupplierSale ? `suppliers/${targetEntityId}/` : `customers/${targetEntityId}/`),
+                    axiosInstance.get('/products/'),
+                    axiosInstance.get('/warehouses/'),
+                ]);
+
+                if (isActiveRef && !isActiveRef()) {
+                    return;
+                }
+
+                setEntity({ currency: 'USD', ...entityResponse.data });
+                setProducts(productsResponse.data || []);
+                setWarehouses(warehousesResponse.data || []);
+            } catch (err) {
+                if (isActiveRef && !isActiveRef()) {
+                    return;
+                }
+
+                console.error('Failed to fetch sale details', err);
+                setError(DEFAULT_ERROR_MESSAGE);
+                setEntity(null);
+                setProducts([]);
+                setWarehouses([]);
+            } finally {
+                if (!isActiveRef || isActiveRef()) {
+                    setIsLoading(false);
+                }
+            }
+        },
+        [isSupplierSale, onBeforeFetch]
+    );
+
+    useEffect(() => {
+        if (!entityId) {
+            setEntity(null);
+            setProducts([]);
+            setWarehouses([]);
+            setError(null);
+            if (onEntityCleared) {
+                onEntityCleared();
+            }
+            return;
+        }
+
+        let isActive = true;
+        const isActiveRef = () => isActive;
+
+        loadEntityData(entityId, isActiveRef);
+
+        return () => {
+            isActive = false;
+        };
+    }, [entityId, loadEntityData, onEntityCleared]);
+
+    const reload = useCallback(() => loadEntityData(entityId), [entityId, loadEntityData]);
+
+    const clearError = useCallback(() => setError(null), []);
+
+    return {
+        entity,
+        products,
+        warehouses,
+        isLoading,
+        error,
+        clearError,
+        reload,
+    };
+}

--- a/frontend/src/hooks/useSaleFormData.test.js
+++ b/frontend/src/hooks/useSaleFormData.test.js
@@ -1,0 +1,101 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import useSaleFormData from './useSaleFormData';
+import axiosInstance from '../utils/axiosInstance';
+
+jest.mock('../utils/axiosInstance', () => ({
+    get: jest.fn(),
+    defaults: { baseURL: '' },
+}));
+
+const buildResponse = (data) => Promise.resolve({ data });
+
+describe('useSaleFormData', () => {
+    beforeEach(() => {
+        axiosInstance.get.mockImplementation((url) => {
+            if (url === 'customers/1/') {
+                return buildResponse({ id: 1, name: 'Acme Corp', currency: 'EUR' });
+            }
+            if (url === '/products/') {
+                return buildResponse([{ id: 1, name: 'Widget' }]);
+            }
+            if (url === '/warehouses/') {
+                return buildResponse([{ id: 10, name: 'Main Warehouse' }]);
+            }
+            return buildResponse({});
+        });
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('loads entity, products, and warehouses for a customer sale', async () => {
+        const { result } = renderHook(() =>
+            useSaleFormData({
+                entityId: 1,
+                isSupplierSale: false,
+            })
+        );
+
+        expect(result.current.isLoading).toBe(true);
+
+        await waitFor(() => {
+            expect(result.current.isLoading).toBe(false);
+        });
+
+        expect(axiosInstance.get).toHaveBeenCalledWith('customers/1/');
+        expect(result.current.entity).toEqual(
+            expect.objectContaining({ id: 1, name: 'Acme Corp', currency: 'EUR' })
+        );
+        expect(result.current.products).toHaveLength(1);
+        expect(result.current.warehouses).toHaveLength(1);
+        expect(result.current.error).toBeNull();
+    });
+
+    it('reports an error when requests fail', async () => {
+        const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        axiosInstance.get.mockRejectedValueOnce(new Error('network error'));
+
+        const { result } = renderHook(() =>
+            useSaleFormData({
+                entityId: 1,
+                isSupplierSale: false,
+            })
+        );
+
+        await waitFor(() => {
+            expect(result.current.error).toBe('Failed to fetch sale details. Please try again.');
+        });
+
+        expect(result.current.entity).toBeNull();
+        expect(result.current.products).toEqual([]);
+        expect(result.current.warehouses).toEqual([]);
+        consoleSpy.mockRestore();
+    });
+
+    it('invokes lifecycle callbacks when entity changes', async () => {
+        const onBeforeFetch = jest.fn();
+        const onEntityCleared = jest.fn();
+
+        const { rerender } = renderHook(
+            ({ entityId }) =>
+                useSaleFormData({
+                    entityId,
+                    isSupplierSale: false,
+                    onBeforeFetch,
+                    onEntityCleared,
+                }),
+            { initialProps: { entityId: 1 } }
+        );
+
+        await waitFor(() => {
+            expect(onBeforeFetch).toHaveBeenCalled();
+        });
+
+        rerender({ entityId: null });
+
+        await waitFor(() => {
+            expect(onEntityCleared).toHaveBeenCalled();
+        });
+    });
+});

--- a/frontend/src/pages/SaleFormPage.js
+++ b/frontend/src/pages/SaleFormPage.js
@@ -2,14 +2,17 @@
 
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
-import { Alert, Badge, Button, Card, Col, Container, Form, Row, Spinner, Stack, Table } from 'react-bootstrap';
-import { PencilSquare, Plus, Trash } from 'react-bootstrap-icons';
+import { Alert, Button, Card, Col, Container, Form, Row, Spinner } from 'react-bootstrap';
 import axiosInstance from '../utils/axiosInstance';
 import '../styles/datatable.css';
 import '../styles/saleForm.css';
-import ProductSearchSelect from '../components/ProductSearchSelect';
 import SaleItemModal from '../components/SaleItemModal';
-import { getBaseApiUrl, getImageInitial, resolveImageUrl } from '../utils/image';
+import useSaleFormData from '../hooks/useSaleFormData';
+import SaleCustomerSelector from '../components/sales/SaleCustomerSelector';
+import SaleSidebarSummary from '../components/sales/SaleSidebarSummary';
+import SaleLineItemsTable from '../components/sales/SaleLineItemsTable';
+import useSaleItemModal from '../components/sales/useSaleItemModal';
+import { getBaseApiUrl } from '../utils/image';
 
 function SaleFormPage({
     mode: modeProp,
@@ -49,13 +52,9 @@ function SaleFormPage({
     const location = useLocation();
     const isOffer = !isEditMode && new URLSearchParams(location.search).get('type') === 'offer';
 
-    const [customer, setCustomer] = useState(null);
-    const [allProducts, setAllProducts] = useState([]);
-    const [warehouses, setWarehouses] = useState([]);
     const [customerOptions, setCustomerOptions] = useState([]);
     const [isLoadingCustomerOptions, setIsLoadingCustomerOptions] = useState(false);
-    const [loadingEntityData, setLoadingEntityData] = useState(false);
-    const [initialDataError, setInitialDataError] = useState(null);
+    const [customerSelectionError, setCustomerSelectionError] = useState(null);
     const todayIso = useMemo(() => new Date().toISOString().slice(0, 10), []);
     const [saleDate, setSaleDate] = useState(initialSaleDate || todayIso);
     const [invoiceDate, setInvoiceDate] = useState(initialInvoiceDate || todayIso);
@@ -65,7 +64,8 @@ function SaleFormPage({
     const [lineItems, setLineItems] = useState(() => initialLineItems.map((item) => ({ ...item })));
     const [formError, setFormError] = useState(null);
     const [isSubmitting, setIsSubmitting] = useState(false);
-    const [itemModalState, setItemModalState] = useState({ show: false, index: null, initialItem: null });
+    const { state: itemModalState, openCreate: openItemCreateModal, openEdit: openItemEditModal, close: closeItemModal } =
+        useSaleItemModal();
     const [quickSearchKey, setQuickSearchKey] = useState(0);
     const [hasHydratedFromProps, setHasHydratedFromProps] = useState(initialLineItems.length > 0);
 
@@ -79,10 +79,10 @@ function SaleFormPage({
             try {
                 const response = await axiosInstance.get('/customers/');
                 setCustomerOptions(response.data || []);
-                setInitialDataError(null);
+                setCustomerSelectionError(null);
             } catch (error) {
                 console.error('Failed to fetch customers', error);
-                setInitialDataError('Failed to load customers. Please try again.');
+                setCustomerSelectionError('Failed to load customers. Please try again.');
             } finally {
                 setIsLoadingCustomerOptions(false);
             }
@@ -107,47 +107,33 @@ function SaleFormPage({
         setHasHydratedFromProps(true);
     }, [hasHydratedFromProps, initialLineItems]);
 
-    useEffect(() => {
-        if (!entityId) {
-            setCustomer(null);
-            setAllProducts([]);
-            setWarehouses([]);
-            if (!isEditMode) {
-                setLineItems([]);
-            }
-            return;
+    const handleResetLineItemsBeforeFetch = useCallback(() => {
+        if (!isEditMode || !hasHydratedFromProps) {
+            setLineItems([]);
         }
+    }, [hasHydratedFromProps, isEditMode]);
 
-        const fetchData = async () => {
-            setLoadingEntityData(true);
-            setInitialDataError(null);
-            setCustomer(null);
-            setAllProducts([]);
-            setWarehouses([]);
-            if (!isEditMode || !hasHydratedFromProps) {
-                setLineItems([]);
-            }
+    const handleEntityCleared = useCallback(() => {
+        if (!isEditMode) {
+            setLineItems([]);
+        }
+    }, [isEditMode]);
 
-            try {
-                const [custRes, prodRes, warehouseRes] = await Promise.all([
-                    axiosInstance.get(isSupplierSale ? `suppliers/${entityId}/` : `customers/${entityId}/`),
-                    axiosInstance.get('/products/'),
-                    axiosInstance.get('/warehouses/'),
-                ]);
-                const entityData = { currency: 'USD', ...custRes.data };
-                setCustomer(entityData);
-                setAllProducts(prodRes.data);
-                setWarehouses(warehouseRes.data);
-            } catch (error) {
-                console.error('Failed to fetch initial data', error);
-                setInitialDataError('Failed to fetch sale details. Please try again.');
-            } finally {
-                setLoadingEntityData(false);
-            }
-        };
+    const {
+        entity: fetchedEntity,
+        products: allProducts,
+        warehouses,
+        isLoading: loadingEntityData,
+        error: entityError,
+        clearError: clearEntityError,
+    } = useSaleFormData({
+        entityId,
+        isSupplierSale,
+        onBeforeFetch: handleResetLineItemsBeforeFetch,
+        onEntityCleared: handleEntityCleared,
+    });
 
-        fetchData();
-    }, [entityId, hasHydratedFromProps, isEditMode, isSupplierSale]);
+    const customer = fetchedEntity;
 
     useEffect(() => {
         if (!entityId) {
@@ -174,25 +160,27 @@ function SaleFormPage({
         return allProducts.find((p) => p.id === Number(productId)) || null;
     }, [allProducts]);
 
-    const openCreateItemModal = (product = null) => {
-        const defaultItem = {
-            product_id: product?.id || '',
-            quantity: product ? 1 : 1,
-            unit_price: product ? Number(product.sale_price) : 0,
-            warehouse_id: warehouses[0]?.id || '',
-            discount: 0,
-            note: '',
-        };
-        setItemModalState({ show: true, index: null, initialItem: defaultItem });
-    };
+    const openCreateItemModal = useCallback(
+        (product = null) => {
+            const defaultItem = {
+                product_id: product?.id || '',
+                quantity: product ? 1 : 1,
+                unit_price: product ? Number(product.sale_price) : 0,
+                warehouse_id: warehouses[0]?.id || '',
+                discount: 0,
+                note: '',
+            };
+            openItemCreateModal(defaultItem);
+        },
+        [openItemCreateModal, warehouses]
+    );
 
-    const openEditItemModal = (index) => {
-        setItemModalState({ show: true, index, initialItem: lineItems[index] });
-    };
-
-    const closeItemModal = () => {
-        setItemModalState({ show: false, index: null, initialItem: null });
-    };
+    const openEditItemModal = useCallback(
+        (index) => {
+            openItemEditModal(index, lineItems[index]);
+        },
+        [lineItems, openItemEditModal]
+    );
 
     const handleSaveItem = (item, index) => {
         const normalized = {
@@ -382,52 +370,30 @@ function SaleFormPage({
 
     const primaryActionLabel = isEditMode ? 'Update Sale' : (isOffer ? 'Save Offer' : 'Save Sale');
 
+    const handleSidebarCustomerChange = useCallback(
+        (value) => {
+            setSelectedCustomerId(value);
+            setLineItems([]);
+            setCustomerSelectionError(null);
+        },
+        []
+    );
+
     return (
         <Container className="sale-form__container">
             {isStandaloneSale && (
-                <Card className="sale-form__selection-card mb-4">
-                    <Card.Body>
-                        <Row className="align-items-end g-3">
-                            <Col md={8}>
-                                <Form.Group controlId="saleCustomer">
-                                    <Form.Label>Select Customer</Form.Label>
-                                    <Form.Select
-                                        value={selectedCustomerId || ''}
-                                        onChange={(event) => {
-                                            const value = event.target.value;
-                                            setSelectedCustomerId(value ? Number(value) : null);
-                                        }}
-                                        disabled={isLoadingCustomerOptions}
-                                    >
-                                        <option value="">Choose a customer...</option>
-                                        {customerOptions.map((option) => (
-                                            <option key={option.id} value={option.id}>
-                                                {option.name}
-                                            </option>
-                                        ))}
-                                    </Form.Select>
-                                </Form.Group>
-                            </Col>
-                            <Col md={4}>
-                                <div className="text-muted small">
-                                    {isLoadingCustomerOptions
-                                        ? 'Loading customers...'
-                                        : 'Select a customer to start a new sale.'}
-                                </div>
-                            </Col>
-                        </Row>
-                        {initialDataError && !entityId && (
-                            <Alert
-                                variant="danger"
-                                className="mt-3"
-                                onClose={() => setInitialDataError(null)}
-                                dismissible
-                            >
-                                {initialDataError}
-                            </Alert>
-                        )}
-                    </Card.Body>
-                </Card>
+                <SaleCustomerSelector
+                    customerOptions={customerOptions}
+                    selectedCustomerId={selectedCustomerId}
+                    onChange={(value) => {
+                        setSelectedCustomerId(value);
+                        setLineItems([]);
+                        setCustomerSelectionError(null);
+                    }}
+                    isLoading={isLoadingCustomerOptions}
+                    error={!entityId ? customerSelectionError : null}
+                    onDismissError={() => setCustomerSelectionError(null)}
+                />
             )}
 
             {!entityId && isStandaloneSale && (
@@ -453,9 +419,9 @@ function SaleFormPage({
                     <div className="d-flex justify-content-center align-items-center py-5">
                         <Spinner animation="border" />
                     </div>
-                ) : initialDataError ? (
-                    <Alert variant="danger" onClose={() => setInitialDataError(null)} dismissible>
-                        {initialDataError}
+                ) : entityError ? (
+                    <Alert variant="danger" onClose={clearEntityError} dismissible>
+                        {entityError}
                     </Alert>
                 ) : (
                     customer && (
@@ -463,295 +429,55 @@ function SaleFormPage({
                             <Form onSubmit={handleSubmit}>
                                 <Row className="sale-form__layout">
                                     <Col xl={4} lg={5} className="mb-4">
-                                        <Card className="sale-form__sidebar-card">
-                                            <Card.Header>
-                                                <div className="sale-form__sidebar-title">
-                                                    <div className="sale-form__sidebar-label">{isEditMode ? 'Edit Sale' : (isOffer ? 'Offer' : 'Sale')} Summary</div>
-                                                    <div className="sale-form__sidebar-entity">{customer.name}</div>
-                                                </div>
-                                            </Card.Header>
-                                            <Card.Body>
-                                                {allowCustomerSwitch && (
-                                                    <Row className="gy-3 mb-1">
-                                                        <Col xs={12}>
-                                                            <Form.Group controlId="saleEditorCustomer">
-                                                                <Form.Label>Customer</Form.Label>
-                                                                <Form.Select
-                                                                    value={selectedCustomerId || ''}
-                                                                    onChange={(event) => {
-                                                                        const value = event.target.value;
-                                                                        const numericValue = value ? Number(value) : null;
-                                                                        setSelectedCustomerId(numericValue);
-                                                                        setLineItems([]);
-                                                                    }}
-                                                                    disabled={isLoadingCustomerOptions}
-                                                                    required
-                                                                >
-                                                                    <option value="">Select a customer</option>
-                                                                    {customerOptions.map((option) => (
-                                                                        <option key={option.id} value={option.id}>
-                                                                            {option.name}
-                                                                        </option>
-                                                                    ))}
-                                                                </Form.Select>
-                                                            </Form.Group>
-                                                        </Col>
-                                                    </Row>
-                                                )}
-                                                <div className="sale-form__entity-meta">
-                                                    {customer.phone && <span>{customer.phone}</span>}
-                                                    {customer.email && <span>{customer.email}</span>}
-                                                    <span>{customer.currency} account</span>
-                                                </div>
-                                <Row className="gy-3 mt-1">
-                                    <Col xs={12}>
-                                        <Form.Group controlId="documentNumber">
-                                            <Form.Label>Document No</Form.Label>
-                                            <Form.Control
-                                                type="text"
-                                                value={documentNumber}
-                                                placeholder="Auto"
-                                                onChange={(event) => setDocumentNumber(event.target.value)}
-                                            />
-                                        </Form.Group>
+                                        <SaleSidebarSummary
+                                            isEditMode={isEditMode}
+                                            isOffer={isOffer}
+                                            customer={customer}
+                                            allowCustomerSwitch={allowCustomerSwitch}
+                                            customerOptions={customerOptions}
+                                            selectedCustomerId={selectedCustomerId}
+                                            onCustomerChange={handleSidebarCustomerChange}
+                                            isLoadingCustomerOptions={isLoadingCustomerOptions}
+                                            documentNumber={documentNumber}
+                                            onDocumentNumberChange={setDocumentNumber}
+                                            saleDate={saleDate}
+                                            onSaleDateChange={setSaleDate}
+                                            invoiceDate={invoiceDate}
+                                            onInvoiceDateChange={setInvoiceDate}
+                                            invoiceNumber={invoiceNumber}
+                                            onInvoiceNumberChange={setInvoiceNumber}
+                                            description={description}
+                                            onDescriptionChange={setDescription}
+                                            totals={totals}
+                                            formatCurrency={formatCurrency}
+                                            hasWarehouses={hasWarehouses}
+                                            hasLineItems={hasLineItems}
+                                            isSubmitting={isSubmitting}
+                                            primaryActionLabel={primaryActionLabel}
+                                            onCancel={handleCancel}
+                                        />
                                     </Col>
-                                    <Col md={6}>
-                                        <Form.Group controlId="saleDate">
-                                            <Form.Label>{isOffer ? 'Offer Date' : 'Sale Date'}</Form.Label>
-                                            <Form.Control
-                                                type="date"
-                                                value={saleDate}
-                                                onChange={(event) => setSaleDate(event.target.value)}
-                                            />
-                                        </Form.Group>
-                                    </Col>
-                                    <Col md={6}>
-                                        <Form.Group controlId="invoiceDate">
-                                            <Form.Label>Invoice Date</Form.Label>
-                                            <Form.Control
-                                                type="date"
-                                                value={invoiceDate}
-                                                onChange={(event) => setInvoiceDate(event.target.value)}
-                                            />
-                                        </Form.Group>
-                                    </Col>
-                                    <Col md={6}>
-                                        <Form.Group controlId="invoiceNumber">
-                                            <Form.Label>Invoice No</Form.Label>
-                                            <Form.Control
-                                                type="text"
-                                                value={invoiceNumber}
-                                                placeholder="Auto"
-                                                onChange={(event) => setInvoiceNumber(event.target.value)}
-                                            />
-                                        </Form.Group>
-                                    </Col>
-                                    <Col xs={12}>
-                                        <Form.Group controlId="description">
-                                            <Form.Label>Description</Form.Label>
-                                            <Form.Control
-                                                as="textarea"
-                                                rows={3}
-                                                value={description}
-                                                onChange={(event) => setDescription(event.target.value)}
-                                                placeholder="Optional notes about this transaction"
-                                            />
-                                        </Form.Group>
+                                    <Col xl={8} lg={7}>
+                                        <SaleLineItemsTable
+                                            isOffer={isOffer}
+                                            products={allProducts}
+                                            lineItems={lineItems}
+                                            warehouses={warehouses}
+                                            hasWarehouses={hasWarehouses}
+                                            formError={formError}
+                                            onDismissFormError={() => setFormError(null)}
+                                            formatCurrency={formatCurrency}
+                                            onQuickProductSelect={handleQuickProductSelect}
+                                            onNewLine={() => openCreateItemModal()}
+                                            quickSearchKey={quickSearchKey}
+                                            onEditItem={openEditItemModal}
+                                            onRemoveItem={handleRemoveItem}
+                                            baseApiUrl={baseApiUrl}
+                                            getProductById={getProductById}
+                                        />
                                     </Col>
                                 </Row>
-                                <div className="sale-form__summary mt-4">
-                                    <div className="sale-form__summary-row">
-                                        <span>Subtotal</span>
-                                        <span>{formatCurrency(totals.base)}</span>
-                                    </div>
-                                    <div className="sale-form__summary-row">
-                                        <span>Discount</span>
-                                        <span>{formatCurrency(totals.discount)}</span>
-                                    </div>
-                                    <div className="sale-form__summary-row sale-form__summary-row--strong">
-                                        <span>Net Total</span>
-                                        <span>{formatCurrency(totals.net)}</span>
-                                    </div>
-                                </div>
-                            </Card.Body>
-                            <Card.Footer>
-                                <Stack gap={2}>
-                                    <Button
-                                        type="submit"
-                                        variant="success"
-                                        disabled={!hasWarehouses || !hasLineItems || isSubmitting}
-                                    >
-                                        {primaryActionLabel}
-                                    </Button>
-                                    <Button
-                                        variant="outline-secondary"
-                                        onClick={handleCancel}
-                                        type="button"
-                                    >
-                                        Cancel
-                                    </Button>
-                                </Stack>
-                            </Card.Footer>
-                        </Card>
-                    </Col>
-                    <Col xl={8} lg={7}>
-                        <Card className="sale-form__items-card">
-                            <Card.Header>
-                                <div className="sale-form__items-header">
-                                    <div>
-                                        <h5 className="mb-0">Products &amp; Services</h5>
-                                        <small className="text-muted">Add items from your catalog to this {isOffer ? 'offer' : 'sale'}.</small>
-                                    </div>
-                                    <div className="sale-form__quick-add">
-                                        <ProductSearchSelect
-                                            key={quickSearchKey}
-                                            products={allProducts}
-                                            value={null}
-                                            onSelect={handleQuickProductSelect}
-                                            placeholder="Search products to add"
-                                            imageBaseUrl={baseApiUrl}
-                                        />
-                                        <Button
-                                            type="button"
-                                            className="mt-2 mt-sm-0"
-                                            variant="outline-primary"
-                                            onClick={() => openCreateItemModal()}
-                                            disabled={!hasWarehouses}
-                                        >
-                                            <Plus className="me-1" /> New Line
-                                        </Button>
-                                    </div>
-                                </div>
-                            </Card.Header>
-                            <Card.Body>
-                                {!hasWarehouses && (
-                                    <Alert variant="warning" className="mb-3">
-                                        No warehouses available. Please create a warehouse before recording sales.
-                                    </Alert>
-                                )}
-                                {formError && (
-                                    <Alert variant="danger" className="mb-3" onClose={() => setFormError(null)} dismissible>
-                                        {formError}
-                                    </Alert>
-                                )}
-                                <div className="table-responsive">
-                                    <Table hover borderless className="sale-items-table align-middle">
-                                        <thead>
-                                            <tr>
-                                                <th>Product</th>
-                                                <th>Warehouse</th>
-                                                <th className="text-center">Stock</th>
-                                                <th className="text-center">Quantity</th>
-                                                <th className="text-end">Unit Price</th>
-                                                <th className="text-center">Discount</th>
-                                                <th className="text-end">Line Total</th>
-                                                <th className="text-end">Actions</th>
-                                            </tr>
-                                        </thead>
-                                        <tbody>
-                                            {lineItems.length === 0 && (
-                                                <tr>
-                                                    <td colSpan={8} className="text-center text-muted py-4">
-                                                        Add products using the search above to build this {isOffer ? 'offer' : 'sale'}.
-                                                    </td>
-                                                </tr>
-                                            )}
-                                            {lineItems.map((item, index) => {
-                                                const product = getProductById(item.product_id);
-                                                const warehouse = warehouses.find((w) => w.id === Number(item.warehouse_id));
-                                                const warehouseQuantity = product?.warehouse_quantities?.find(
-                                                    (stock) => stock.warehouse_id === Number(item.warehouse_id)
-                                                );
-                                                const availableStock = warehouseQuantity ? Number(warehouseQuantity.quantity) : null;
-                                                const discountLabel = item.discount ? `${Number(item.discount).toFixed(2)}%` : '—';
-                                                const lineTotal = Number(item.quantity) * Number(item.unit_price || 0);
-                                                const resolvedImage = resolveImageUrl(product?.image, baseApiUrl);
-                                                const imageInitial = getImageInitial(product?.name);
-                                                const metaDetails = [];
-
-                                                if (item.note) {
-                                                    metaDetails.push(
-                                                        <span key="note">Note: {item.note}</span>
-                                                    );
-                                                }
-
-                                                return (
-                                                    <tr key={`${item.product_id}-${index}`}>
-                                                        <td>
-                                                            <div className="sale-items-table__product product-name-cell">
-                                                                <div className="product-name-cell__image">
-                                                                    {resolvedImage ? (
-                                                                        <img src={resolvedImage} alt={product?.name || 'Product preview'} />
-                                                                    ) : (
-                                                                        <span>{imageInitial}</span>
-                                                                    )}
-                                                                </div>
-                                                                <div className="sale-items-table__info product-name-cell__info product-name-cell__body">
-                                                                    <div className="product-name-cell__header">
-                                                                        <div className="sale-items-table__name product-name-cell__name">
-                                                                            {product?.name || 'Unnamed product'}
-                                                                        </div>
-                                                                        {product?.sku && (
-                                                                            <span className="product-name-cell__badge">SKU {product.sku}</span>
-                                                                        )}
-                                                                    </div>
-                                                                    {metaDetails.length > 0 && (
-                                                                        <div className="sale-items-table__meta product-name-cell__meta">
-                                                                            {metaDetails}
-                                                                        </div>
-                                                                    )}
-                                                                </div>
-                                                            </div>
-                                                        </td>
-                                                        <td>
-                                                            {warehouse ? (
-                                                                <span>{warehouse.name}</span>
-                                                            ) : (
-                                                                <span className="text-muted">No warehouse</span>
-                                                            )}
-                                                        </td>
-                                                        <td className="text-center">
-                                                            {product ? (
-                                                                <Badge bg={availableStock && availableStock > 0 ? 'success' : 'danger'}>
-                                                                    {availableStock !== null ? `${availableStock}` : 'No data'}
-                                                                </Badge>
-                                                            ) : (
-                                                                <span className="text-muted">Select a product</span>
-                                                            )}
-                                                        </td>
-                                                        <td className="text-center">{Number(item.quantity)}</td>
-                                                        <td className="text-end">{formatCurrency(item.unit_price)}</td>
-                                                        <td className="text-center">{discountLabel}</td>
-                                                        <td className="text-end">{formatCurrency(lineTotal)}</td>
-                                                        <td className="text-end">
-                                                            <div className="sale-items-table__actions">
-                                                                <Button
-                                                                    variant="outline-secondary"
-                                                                    size="sm"
-                                                                    onClick={() => openEditItemModal(index)}
-                                                                >
-                                                                    <PencilSquare />
-                                                                </Button>
-                                                                <Button
-                                                                    variant="outline-danger"
-                                                                    size="sm"
-                                                                    onClick={() => handleRemoveItem(index)}
-                                                                >
-                                                                    <Trash />
-                                                                </Button>
-                                                            </div>
-                                                        </td>
-                                                    </tr>
-                                                );
-                                            })}
-                                        </tbody>
-                                    </Table>
-                                </div>
-                            </Card.Body>
-                        </Card>
-                    </Col>
-                </Row>
-            </Form>
+                            </Form>
                             <SaleItemModal
                                 show={itemModalState.show}
                                 onHide={closeItemModal}


### PR DESCRIPTION
## Summary
- add a useSaleFormData hook to centralize entity/product/warehouse loading and expose loading state for the sale form
- extract the sale customer selector, summary sidebar, line items table, and item modal reducer into dedicated components/hooks and compose them from SaleFormPage
- align existing payment/App tests with the new helpers and add unit tests that cover the sale hook and subcomponents

## Testing
- npm test -- src/components/sales/SaleCustomerSelector.test.js src/components/sales/SaleSidebarSummary.test.js src/components/sales/SaleLineItemsTable.test.js src/components/sales/useSaleItemModal.test.js src/hooks/useSaleFormData.test.js --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68e64fb6ee0483238ae929c9712972ea