### PR TITLE
Improve summary card readability on customer and supplier pages

### DIFF
--- a/frontend/src/pages/CustomerDetailPage.css
+++ b/frontend/src/pages/CustomerDetailPage.css
@@ -1,14 +1,4 @@
 /* frontend/src/pages/CustomerDetailPage.css */
-
-.summary-card .card-body {
-    display: flex;
-    align-items: center;
-}
-
-.summary-card .icon {
-    font-size: 40px;
-}
-
 /* Speech bubble styling */
 .speech-bubble {
     background: #e9f7fe;
@@ -26,18 +16,6 @@
     border-width: 10px;
     border-style: solid;
     border-color: #e9f7fe transparent transparent transparent;
-}
-
-@media (max-width: 768px) {
-    .summary-card .card-body {
-        flex-direction: column;
-        text-align: center;
-    }
-
-    .summary-card .icon {
-        margin-right: 0;
-        margin-bottom: 0.5rem;
-    }
 }
 
 .customer-image {

--- a/frontend/src/pages/CustomerDetailPage.js
+++ b/frontend/src/pages/CustomerDetailPage.js
@@ -6,6 +6,7 @@ import axiosInstance from '../utils/axiosInstance';
 import { Container, Card, Row, Col, Spinner, Alert, Button, Accordion, ButtonToolbar, Table, Modal } from 'react-bootstrap';
 import { PersonCircle, Cash, Tag, Hammer, BarChart, PencilSquare, Trash, ReceiptCutoff, Wallet2, CartCheck, Printer } from 'react-bootstrap-icons';
 import './CustomerDetailPage.css';
+import '../styles/metric-cards.css';
 import ActionMenu from '../components/ActionMenu';
 import '../styles/datatable.css';
 import '../styles/transaction-history.css';
@@ -139,13 +140,15 @@ function CustomerDetailPage() {
         return formatCurrency(displayValue, currency);
     };
 
-    const renderSummaryCard = (bg, title, amount, Icon) => (
-        <Card bg={bg} text="white" className="summary-card">
-            <Card.Body className="d-flex align-items-center">
-                <Icon size={40} className="icon me-3" />
+    const renderSummaryCard = (variant, title, amount, Icon) => (
+        <Card className={`summary-card metric-card metric-card--${variant}`}>
+            <Card.Body className="metric-card__body">
+                <div className="metric-card__icon">
+                    <Icon size={28} />
+                </div>
                 <div>
-                    <h6 className="mb-0">{title}</h6>
-                    <div className="fs-4">{amount}</div>
+                    <p className="metric-card__title mb-1">{title}</p>
+                    <p className="metric-card__value">{amount}</p>
                 </div>
             </Card.Body>
         </Card>

--- a/frontend/src/pages/SupplierDetailPage.css
+++ b/frontend/src/pages/SupplierDetailPage.css
@@ -1,12 +1,3 @@
-.summary-card {
-    color: white;
-    height: 100%;
-}
-
-.summary-card .icon {
-    opacity: 0.8;
-}
-
 .customer-header {
     position: relative;
 }

--- a/frontend/src/pages/SupplierDetailPage.js
+++ b/frontend/src/pages/SupplierDetailPage.js
@@ -6,6 +6,7 @@ import axiosInstance from '../utils/axiosInstance';
 import { Container, Card, Row, Col, Spinner, Alert, Button, Accordion, ButtonToolbar, Table } from 'react-bootstrap';
 import { PersonCircle, Cash, Tag, Hammer, BarChart, PencilSquare, Trash, ReceiptCutoff, Wallet2, CartCheck, Printer } from 'react-bootstrap-icons';
 import './SupplierDetailPage.css';
+import '../styles/metric-cards.css';
 import ActionMenu from '../components/ActionMenu';
 import '../styles/datatable.css';
 import '../styles/transaction-history.css';
@@ -186,13 +187,15 @@ function SupplierDetailPage() {
         return new Intl.NumberFormat('en-US', { style: 'currency', currency: currency || 'USD' }).format(amount);
     };
 
-    const renderSummaryCard = (bg, title, amount, Icon) => (
-        <Card bg={bg} text="white" className="summary-card">
-            <Card.Body className="d-flex align-items-center">
-                <Icon size={40} className="icon me-3" />
+    const renderSummaryCard = (variant, title, amount, Icon) => (
+        <Card className={`summary-card metric-card metric-card--${variant}`}>
+            <Card.Body className="metric-card__body">
+                <div className="metric-card__icon">
+                    <Icon size={28} />
+                </div>
                 <div>
-                    <h6 className="mb-0">{title}</h6>
-                    <div className="fs-4">{amount}</div>
+                    <p className="metric-card__title mb-1">{title}</p>
+                    <p className="metric-card__value">{amount}</p>
                 </div>
             </Card.Body>
         </Card>

--- a/frontend/src/styles/metric-cards.css
+++ b/frontend/src/styles/metric-cards.css
@@ -1,0 +1,98 @@
+.summary-card.metric-card {
+    --metric-card-bg: #f8fafc;
+    --metric-card-color: #0f172a;
+    --metric-card-icon-bg: rgba(15, 23, 42, 0.08);
+    --metric-card-icon-color: var(--metric-card-color);
+    --metric-card-shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
+
+    background: var(--metric-card-bg);
+    color: var(--metric-card-color);
+    border: none;
+    border-radius: 1.25rem;
+    box-shadow: var(--metric-card-shadow);
+    height: 100%;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.summary-card.metric-card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 16px 32px rgba(15, 23, 42, 0.12);
+}
+
+.summary-card.metric-card .metric-card__body {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 1.5rem;
+}
+
+.summary-card.metric-card .metric-card__icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 3.25rem;
+    height: 3.25rem;
+    border-radius: 1rem;
+    background: var(--metric-card-icon-bg);
+    color: var(--metric-card-icon-color);
+    flex-shrink: 0;
+}
+
+.summary-card.metric-card .metric-card__title {
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    margin-bottom: 0.35rem;
+    color: var(--metric-card-color);
+    opacity: 0.85;
+    font-weight: 600;
+}
+
+.summary-card.metric-card .metric-card__value {
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: var(--metric-card-color);
+    margin: 0;
+}
+
+.summary-card.metric-card--success {
+    --metric-card-bg: #ecfdf3;
+    --metric-card-color: #047857;
+    --metric-card-icon-bg: rgba(16, 185, 129, 0.18);
+    --metric-card-icon-color: #047857;
+}
+
+.summary-card.metric-card--danger {
+    --metric-card-bg: #fef2f2;
+    --metric-card-color: #b91c1c;
+    --metric-card-icon-bg: rgba(248, 113, 113, 0.22);
+    --metric-card-icon-color: #b91c1c;
+}
+
+.summary-card.metric-card--warning {
+    --metric-card-bg: #fff7ed;
+    --metric-card-color: #92400e;
+    --metric-card-icon-bg: rgba(251, 191, 36, 0.25);
+    --metric-card-icon-color: #b45309;
+}
+
+.summary-card.metric-card--info {
+    --metric-card-bg: #eff6ff;
+    --metric-card-color: #1d4ed8;
+    --metric-card-icon-bg: rgba(96, 165, 250, 0.25);
+    --metric-card-icon-color: #1d4ed8;
+}
+
+.summary-card.metric-card--secondary {
+    --metric-card-bg: #f1f5f9;
+    --metric-card-color: #0f172a;
+    --metric-card-icon-bg: rgba(15, 23, 42, 0.12);
+    --metric-card-icon-color: #0f172a;
+}
+
+@media (max-width: 768px) {
+    .summary-card.metric-card .metric-card__body {
+        flex-direction: column;
+        text-align: center;
+    }
+}


### PR DESCRIPTION
## Summary
- restyle customer and supplier summary cards with high-contrast palettes and consistent typography
- add a shared metric card stylesheet so the cards no longer rely on gradients that reduced legibility

## Testing
- Not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e658d767948323b5940012c038c1d3