### PR TITLE
Fix metric card overflow for long currency values

### DIFF
--- a/frontend/src/pages/CustomerDetailPage.js
+++ b/frontend/src/pages/CustomerDetailPage.js
@@ -129,7 +129,9 @@ function CustomerDetailPage() {
     
     const formatCurrency = (amount, currency) => {
         const value = isNaN(Number(amount)) ? 0 : Number(amount);
-        return new Intl.NumberFormat('en-US', { style: 'currency', currency: currency || 'USD' }).format(value);
+        return new Intl.NumberFormat('en-US', { style: 'currency', currency: currency || 'USD' })
+            .format(value)
+            .replace(/\u00A0/g, ' ');
     };
 
     // Format balances so debts (positive numbers) appear with a minus sign
@@ -146,7 +148,7 @@ function CustomerDetailPage() {
                 <div className="metric-card__icon">
                     <Icon size={28} />
                 </div>
-                <div>
+                <div className="metric-card__content">
                     <p className="metric-card__title mb-1">{title}</p>
                     <p className="metric-card__value">{amount}</p>
                 </div>

--- a/frontend/src/styles/metric-cards.css
+++ b/frontend/src/styles/metric-cards.css
@@ -26,6 +26,10 @@
     padding: 1.5rem;
 }
 
+.summary-card.metric-card .metric-card__content {
+    min-width: 0;
+}
+
 .summary-card.metric-card .metric-card__icon {
     display: inline-flex;
     align-items: center;
@@ -49,10 +53,11 @@
 }
 
 .summary-card.metric-card .metric-card__value {
-    font-size: 1.5rem;
+    font-size: clamp(1.125rem, 1.1vw + 1rem, 1.5rem);
     font-weight: 700;
     color: var(--metric-card-color);
     margin: 0;
+    word-break: break-word;
 }
 
 .summary-card.metric-card--success {


### PR DESCRIPTION
## Summary
- allow the summary card content to shrink by wrapping text in a dedicated container
- normalize formatted currency spacing to prevent non-breaking space overflow
- scale the metric value typography to avoid long balances spilling out of the card

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68e65d5b8e988323b08c75513a65d5dc