### PR TITLE
Adjust minus placement for customer balance formatting

### DIFF
--- a/frontend/src/pages/CustomerDetailPage.js
+++ b/frontend/src/pages/CustomerDetailPage.js
@@ -138,8 +138,21 @@ function CustomerDetailPage() {
     // and credits (negative numbers) appear as positive values
     const formatBalance = (amount, currency) => {
         const value = isNaN(Number(amount)) ? 0 : Number(amount);
-        const displayValue = value > 0 ? -value : Math.abs(value);
-        return formatCurrency(displayValue, currency);
+        if (value === 0) {
+            return formatCurrency(0, currency);
+        }
+
+        const formatted = formatCurrency(Math.abs(value), currency);
+
+        if (value > 0) {
+            if (/^[A-Z]{3} /.test(formatted)) {
+                return formatted.replace(/^([A-Z]{3})\s/, '$1 -');
+            }
+
+            return `-${formatted}`;
+        }
+
+        return formatted;
     };
 
     const renderSummaryCard = (variant, title, amount, Icon) => (


### PR DESCRIPTION
## Summary
- adjust customer balance formatting so ISO currency codes display the minus sign before the amount instead of before the code
- preserve existing positive/credit formatting and zero handling in the customer detail summary cards

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68e6604a525083238f835dc90503f09c