### PR TITLE
Fix data table text contrast

### DIFF
--- a/frontend/src/styles/datatable.css
+++ b/frontend/src/styles/datatable.css
@@ -29,7 +29,6 @@
 .data-table {
   width: 100%;
   color: var(--text-color-primary, var(--color-neutral-900, #0f172a));
-  color: var(--text-primary);
   background-color: transparent;
   border-collapse: separate;
   border-spacing: 0;
@@ -41,10 +40,7 @@
     rgba(148, 163, 184, 0.25),
     rgba(37, 99, 235, 0.08)
   );
-  color: var(--text-color-primary, var(--color-neutral-900, #0f172a));
-
-  background: linear-gradient(135deg, rgba(20, 32, 68, 0.94), rgba(37, 99, 235, 0.16));
-  color: var(--text-primary);
+  color: var(--color-neutral-900, #0f172a);
   font-size: 0.8125rem;
   font-weight: 600;
   letter-spacing: 0.04em;
@@ -62,7 +58,7 @@
 .data-table tbody td {
   padding: 0.9rem 1rem;
   border-bottom: 1px solid rgba(148, 163, 184, 0.18);
-  color: var(--text-color-primary, var(--color-neutral-900, #0f172a));
+  color: var(--color-neutral-900, #0f172a);
   vertical-align: middle;
 }
 
@@ -102,13 +98,7 @@
 }
 
 .data-table-empty strong {
-  color: var(--text-color-primary, var(--color-neutral-900, #0f172a));
-
-  color: var(--text-secondary);
-}
-
-.data-table-empty strong {
-  color: var(--text-primary);
+  color: var(--color-neutral-900, #0f172a);
 }
 
 .data-table-toolbar {
@@ -137,27 +127,22 @@
 }
 
 .data-table--subtle tbody td {
-  color: var(--text-color-primary, var(--color-neutral-900, #0f172a));
-  color: var(--text-primary);
+  color: var(--color-neutral-700, #334155);
 }
 
 .data-table tr.table-success td {
   background: rgba(34, 197, 94, 0.18);
-  color: var(--text-color-primary, var(--color-neutral-900, #0f172a));
-  color: var(--text-primary);
+  color: var(--color-neutral-900, #0f172a);
 }
 
 .data-table tr.table-danger td {
   background: rgba(239, 68, 68, 0.18);
-  color: var(--text-color-primary, var(--color-neutral-900, #0f172a));
-  color: var(--text-primary);
+  color: var(--color-neutral-900, #0f172a);
 }
 
 .data-table tr.table-info td {
   background: rgba(59, 130, 246, 0.18);
-  color: var(--text-color-primary, var(--color-neutral-900, #0f172a));
-
-  color: var(--text-primary);
+  color: var(--color-neutral-900, #0f172a);
 }
 
 .data-table thead th.text-end,


### PR DESCRIPTION
## Summary
- update the shared data table styles to use dark text on light table surfaces
- clean up duplicated color declarations so table and status rows inherit appropriate neutral colors

## Testing
- not run (CSS-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690dbef59ab083238dbedc8e77547955)