### PR TITLE
Adjust data table header background

### DIFF
--- a/frontend/src/styles/datatable.css
+++ b/frontend/src/styles/datatable.css
@@ -35,11 +35,7 @@
 }
 
 .data-table thead th {
-  background: linear-gradient(
-    135deg,
-    rgba(148, 163, 184, 0.25),
-    rgba(37, 99, 235, 0.08)
-  );
+  background: var(--color-neutral-100, #e2e8f0);
   color: var(--color-neutral-900, #0f172a);
   font-size: 0.8125rem;
   font-weight: 600;


### PR DESCRIPTION
## Summary
- replace the gradient header fill on data tables with a neutral surface tone for a cleaner look

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690dc1e42a3c8323a25075f134d3256b)