### PR TITLE
Fix Product SKU validation account resolution

### DIFF
--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -668,7 +668,11 @@ class ProductSerializer(AccountScopedSerializerMixin, serializers.ModelSerialize
     def validate_sku(self, value):
         if not value:
             return None
-        account = self.get_account()
+        account = getattr(self.instance, 'account', None)
+        if account is None:
+            account = self.context.get('account')
+        if account is None:
+            account = self.get_account()
         if not account:
             return value
         qs = Product.objects.filter(account=account, sku=value)


### PR DESCRIPTION
## Summary
- ensure ProductSerializer.validate_sku resolves the account from the instance, serializer context, or request before checking SKU uniqueness

## Testing
- python manage.py test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69160e0179d08323802a385d2c2349da)